### PR TITLE
Replace mktime() with time()

### DIFF
--- a/module/ErsBase/oldEntitiy/Code.php
+++ b/module/ErsBase/oldEntitiy/Code.php
@@ -186,8 +186,8 @@ class Code implements InputFilterAwareInterface
         $alphabet = "0123456789ACDFHKMNPRUVWXY";
         $memory = '';
         $n = '';
-        #srand(mktime()); 
-        srand(rand()*mktime());
+        #srand(time());
+        srand(rand()*time());
         for ($i = 0; $i < $this->length; $i++) {
             
             while($n == '' || $memory == $alphabet[$n]) {

--- a/module/ErsBase/oldEntitiy/Order.php
+++ b/module/ErsBase/oldEntitiy/Order.php
@@ -192,8 +192,8 @@ class Order implements InputFilterAwareInterface
         $alphabet = "0123456789ACDFGHKMNPRUVWXY";
         $memory = '';
         $n = '';
-        #srand(mktime()); 
-        srand(rand()*mktime());
+        #srand(time());
+        srand(rand()*time());
         for ($i = 0; $i < $this->length; $i++) {
             
             while($n == '' || $memory == $alphabet[$n]) {

--- a/module/ErsBase/oldEntitiy/User.php
+++ b/module/ErsBase/oldEntitiy/User.php
@@ -479,8 +479,8 @@ class User implements UserInterface, ProviderInterface
         $alphabet = "0123456789ACDFGHKMNPRUVWXY";
         $memory = '';
         $n = '';
-        #srand(mktime()); 
-        srand(rand()*mktime());
+        #srand(time());
+        srand(rand()*time());
         for ($i = 0; $i < $this->length; $i++) {
             
             while($n == '' || $memory == $alphabet[$n]) {

--- a/module/ErsBase/src/ErsBase/Entity/Code.php
+++ b/module/ErsBase/src/ErsBase/Entity/Code.php
@@ -60,8 +60,8 @@ class Code extends Base\Code
         $alphabet = "0123456789ACDFHKMNPRUVWXY";
         $memory = '';
         $n = '';
-        #srand(mktime()); 
-        srand(rand()*mktime());
+        #srand(time());
+        srand(rand()*time());
         for ($i = 0; $i < $this->length; $i++) {
             
             while($n == '' || $memory == $alphabet[$n]) {

--- a/module/ErsBase/src/ErsBase/Entity/Order.php
+++ b/module/ErsBase/src/ErsBase/Entity/Order.php
@@ -76,8 +76,8 @@ class Order extends Base\Order
         $alphabet = "0123456789ACDFGHKMNPRUVWXY";
         $memory = '';
         $n = '';
-        #srand(mktime()); 
-        srand(rand()*mktime());
+        #srand(time());
+        srand(rand()*time());
         for ($i = 0; $i < $this->length; $i++) {
             
             while($n == '' || $memory == $alphabet[$n]) {

--- a/module/ErsBase/src/ErsBase/Entity/User.php
+++ b/module/ErsBase/src/ErsBase/Entity/User.php
@@ -69,8 +69,8 @@ class User extends Base\User implements UserInterface, ProviderInterface
         $alphabet = "0123456789ACDFGHKMNPRUVWXY";
         $memory = '';
         $n = '';
-        #srand(mktime());
-        srand(rand()*mktime());
+        #srand(time());
+        srand(rand()*time());
         for ($i = 0; $i < $this->length; $i++) {
 
             while($n == '' || $memory == $alphabet[$n]) {


### PR DESCRIPTION
Both return the current Unix timestamp.
When called with no arguments, mktime() throws E_STRICT notice.

> Strict standards: mktime(): You should be using the time() function instead

http://php.net/manual/en/function.mktime.php
http://php.net/manual/en/function.time.php