### PR TITLE
Convert "ErsBase\Entity\MyModel" to 'ErsBase\Entity\MyModel'

### DIFF
--- a/module/Admin/Module.php
+++ b/module/Admin/Module.php
@@ -60,7 +60,7 @@ class Module
                     $form   = new Form\Product();
                     
                     $em = $sm->get('doctrine.entitymanager');
-                    $taxes = $em->getRepository("ErsBase\Entity\Tax")->findAll();
+                    $taxes = $em->getRepository('ErsBase\Entity\Tax')->findAll();
                     
                     $options = array();
                     foreach($taxes as $tax) {
@@ -75,7 +75,7 @@ class Module
                     $form = new Form\Role();
                     
                     $em = $sm->get('doctrine.entitymanager');
-                    $roles = $em->getRepository("ErsBase\Entity\UserRole")->findBy(array(), array('roleId' => 'ASC'));
+                    $roles = $em->getRepository('ErsBase\Entity\UserRole')->findBy(array(), array('roleId' => 'ASC'));
                     
                     $options = array();
                     $options[null] = 'no parent';

--- a/module/Admin/src/Admin/Controller/AgegroupController.php
+++ b/module/Admin/src/Admin/Controller/AgegroupController.php
@@ -21,7 +21,7 @@ class AgegroupController extends AbstractActionController {
             ->get('Doctrine\ORM\EntityManager');
         
         return new ViewModel(array(
-            'agegroups' => $em->getRepository("ErsBase\Entity\Agegroup")
+            'agegroups' => $em->getRepository('ErsBase\Entity\Agegroup')
                 ->findBy(array(), array('agegroup' => 'ASC')),
          ));
     }
@@ -68,7 +68,7 @@ class AgegroupController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $agegroup = $em->getRepository("ErsBase\Entity\Agegroup")->findOneBy(array('id' => $id));
+        $agegroup = $em->getRepository('ErsBase\Entity\Agegroup')->findOneBy(array('id' => $id));
 
         $form = new Form\Agegroup();
         $form->bind($agegroup);
@@ -101,7 +101,7 @@ class AgegroupController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $agegroup = $em->getRepository("ErsBase\Entity\Agegroup")
+        $agegroup = $em->getRepository('ErsBase\Entity\Agegroup')
                 ->findOneBy(array('id' => $id));
         $productprices = $agegroup->getProductPrices();
 
@@ -111,7 +111,7 @@ class AgegroupController extends AbstractActionController {
 
             if ($del == 'Yes') {
                 $id = (int) $request->getPost('id');
-                $agegroup = $em->getRepository("ErsBase\Entity\Agegroup")
+                $agegroup = $em->getRepository('ErsBase\Entity\Agegroup')
                     ->findOneBy(array('id' => $id));
                 $em->remove($agegroup);
                 $em->flush();

--- a/module/Admin/src/Admin/Controller/AjaxController.php
+++ b/module/Admin/src/Admin/Controller/AjaxController.php
@@ -25,7 +25,7 @@ class AjaxController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $order = $em->getRepository("ErsBase\Entity\Order")
+        $order = $em->getRepository('ErsBase\Entity\Order')
                 #->findOneBy(array('id' => '297'));
                 #->findOneBy(array('id' => '12'));
                 #->findOneBy(array('id' => '54'));
@@ -47,10 +47,10 @@ class AjaxController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $bankaccount = $em->getRepository("ErsBase\Entity\BankAccount")
+        $bankaccount = $em->getRepository('ErsBase\Entity\BankAccount')
                 ->findOneBy(array('id' => $id));
         
-        $qb = $em->getRepository("ErsBase\Entity\BankStatement")->createQueryBuilder('s');
+        $qb = $em->getRepository('ErsBase\Entity\BankStatement')->createQueryBuilder('s');
         $qb->leftJoin('s.matches', 'm');
         if($bankaccount->getVirtual()) {
             $qb->where(
@@ -96,7 +96,7 @@ class AjaxController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $statement = $em->getRepository("ErsBase\Entity\BankStatement")
+        $statement = $em->getRepository('ErsBase\Entity\BankStatement')
                 ->findOneBy(array('id' => $id));
         
         $viewModel->setVariable("statement", $statement);
@@ -110,7 +110,7 @@ class AjaxController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $bankaccount = $em->getRepository("ErsBase\Entity\BankAccount")
+        $bankaccount = $em->getRepository('ErsBase\Entity\BankAccount')
                 ->findOneBy(array('id' => $id));
         
         return $bankaccount->getVirtual();

--- a/module/Admin/src/Admin/Controller/BankaccountController.php
+++ b/module/Admin/src/Admin/Controller/BankaccountController.php
@@ -21,7 +21,7 @@ class BankaccountController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $accounts = $em->getRepository("ErsBase\Entity\BankAccount")
+        $accounts = $em->getRepository('ErsBase\Entity\BankAccount')
                 ->findBy(array());
         
         return new ViewModel(array(
@@ -71,7 +71,7 @@ class BankaccountController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $bankaccount = $em->getRepository("ErsBase\Entity\BankAccount")->findOneBy(array('id' => $id));
+        $bankaccount = $em->getRepository('ErsBase\Entity\BankAccount')->findOneBy(array('id' => $id));
 
         $form = new Form\BankAccount();
         $form->bind($bankaccount);
@@ -104,7 +104,7 @@ class BankaccountController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $bankaccount = $em->getRepository("ErsBase\Entity\BankAccount")
+        $bankaccount = $em->getRepository('ErsBase\Entity\BankAccount')
                 ->findOneBy(array('id' => $id));
         
         $request = $this->getRequest();
@@ -113,7 +113,7 @@ class BankaccountController extends AbstractActionController {
 
             if ($del == 'Yes') {
                 $id = (int) $request->getPost('id');
-                $bankaccount = $em->getRepository("ErsBase\Entity\BankAccount")
+                $bankaccount = $em->getRepository('ErsBase\Entity\BankAccount')
                     ->findOneBy(array('id' => $id));
                 $em->remove($bankaccount);
                 $em->flush();
@@ -136,12 +136,12 @@ class BankaccountController extends AbstractActionController {
         
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $bankaccount = $em->getRepository("ErsBase\Entity\BankAccount")
+        $bankaccount = $em->getRepository('ErsBase\Entity\BankAccount')
                 ->findOneBy(array('id' => $id));
         
         $form = new Form\BankAccountFormat();
         
-        $statements = $em->getRepository("ErsBase\Entity\BankStatement")
+        $statements = $em->getRepository('ErsBase\Entity\BankStatement')
                 ->findBy(
                         array('bank_account_id' => $bankaccount->getId()),
                         array(),
@@ -207,7 +207,7 @@ class BankaccountController extends AbstractActionController {
                 $data = $form->getData();
                 
                 $id = (int) $request->getPost('id');
-                $bankaccount = $em->getRepository("ErsBase\Entity\BankAccount")
+                $bankaccount = $em->getRepository('ErsBase\Entity\BankAccount')
                     ->findOneBy(array('id' => $id));
                 
                 $format = array(
@@ -230,7 +230,7 @@ class BankaccountController extends AbstractActionController {
                     $em->persist($amountCol);
                     $statement->generateHash();
                     
-                    $bankstatement = $em->getRepository("ErsBase\Entity\BankStatement")
+                    $bankstatement = $em->getRepository('ErsBase\Entity\BankStatement')
                         ->findOneBy(array('hash' => $statement->getHash()));
                     if($bankstatement) {
                         error_log('the statement with hash '.$statement->getHash().' already exists.');
@@ -294,7 +294,7 @@ class BankaccountController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $accounts = $em->getRepository("ErsBase\Entity\BankAccount")
+        $accounts = $em->getRepository('ErsBase\Entity\BankAccount')
                 ->findBy(array());
         
         $options = array();
@@ -319,7 +319,7 @@ class BankaccountController extends AbstractActionController {
                 $data = $form->getData();
                 
                 $id = $data['bankaccount_id'];
-                $bankaccount = $em->getRepository("ErsBase\Entity\BankAccount")
+                $bankaccount = $em->getRepository('ErsBase\Entity\BankAccount')
                     ->findOneBy(array('id' => $id));
                 
                 $file = $data['csv-upload'];
@@ -370,7 +370,7 @@ class BankaccountController extends AbstractActionController {
                     }
                     $bs->generateHash();
                     
-                    $bankstatement = $em->getRepository("ErsBase\Entity\BankStatement")
+                    $bankstatement = $em->getRepository('ErsBase\Entity\BankStatement')
                         ->findOneBy(array('hash' => $bs->getHash()));
                     if($bankstatement) {
                         continue;
@@ -415,7 +415,7 @@ class BankaccountController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $order = $em->getRepository("ErsBase\Entity\Order")
+        $order = $em->getRepository('ErsBase\Entity\Order')
                 ->findOneBy(array('id' => $id));
         
         return new ViewModel(array(
@@ -431,7 +431,7 @@ class BankaccountController extends AbstractActionController {
         
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $bankaccount = $em->getRepository("ErsBase\Entity\BankAccount")
+        $bankaccount = $em->getRepository('ErsBase\Entity\BankAccount')
                 ->findOneBy(array('id' => $id));
         
         return new ViewModel(array(
@@ -447,7 +447,7 @@ class BankaccountController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $csv = $em->getRepository("ErsBase\Entity\BankAccountCsv")
+        $csv = $em->getRepository('ErsBase\Entity\BankAccountCsv')
                 ->findOneBy(array('id' => $id));
         
         $request = $this->getRequest();
@@ -456,7 +456,7 @@ class BankaccountController extends AbstractActionController {
 
             if ($del == 'Yes') {
                 $id = (int) $request->getPost('id');
-                $csv = $em->getRepository("ErsBase\Entity\BankAccountCsv")
+                $csv = $em->getRepository('ErsBase\Entity\BankAccountCsv')
                     ->findOneBy(array('id' => $id));
                 if($csv->hasMatch()) {
                     return $this->redirect()->toRoute('admin/bankaccount');

--- a/module/Admin/src/Admin/Controller/CounterController.php
+++ b/module/Admin/src/Admin/Controller/CounterController.php
@@ -21,7 +21,7 @@ class CounterController extends AbstractActionController {
             ->get('Doctrine\ORM\EntityManager');
         
         return new ViewModel(array(
-            'counters' => $em->getRepository("ErsBase\Entity\Counter")->findAll(),
+            'counters' => $em->getRepository('ErsBase\Entity\Counter')->findAll(),
          ));
     }
 
@@ -69,7 +69,7 @@ class CounterController extends AbstractActionController {
         
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $counter = $em->getRepository("ErsBase\Entity\Counter")->find($id);
+        $counter = $em->getRepository('ErsBase\Entity\Counter')->find($id);
         if(!$counter) {
             return $this->notFoundAction();
         }
@@ -116,7 +116,7 @@ class CounterController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $counter = $em->getRepository("ErsBase\Entity\Counter")
+        $counter = $em->getRepository('ErsBase\Entity\Counter')
                 ->find($id);
         if(!$counter) {
             return $this->notFoundAction();
@@ -128,7 +128,7 @@ class CounterController extends AbstractActionController {
 
             if ($del == 'Yes') {
                 $id = (int) $request->getPost('id');
-                $counter = $em->getRepository("ErsBase\Entity\Counter")
+                $counter = $em->getRepository('ErsBase\Entity\Counter')
                     ->findOneBy(array('id' => $id));
                 $em->remove($counter);
                 $em->flush();

--- a/module/Admin/src/Admin/Controller/CountryController.php
+++ b/module/Admin/src/Admin/Controller/CountryController.php
@@ -23,12 +23,12 @@ class CountryController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $qb1 = $em->getRepository("ErsBase\Entity\Country")->createQueryBuilder('n');
+        $qb1 = $em->getRepository('ErsBase\Entity\Country')->createQueryBuilder('n');
         $qb1->where($qb1->expr()->isNotNull('n.position'));
         $qb1->orderBy('n.position', 'ASC');
         $result1 = $qb1->getQuery()->getResult();
         
-        $qb2 = $em->getRepository("ErsBase\Entity\Country")->createQueryBuilder('n');
+        $qb2 = $em->getRepository('ErsBase\Entity\Country')->createQueryBuilder('n');
         $qb2->where($qb2->expr()->isNull('n.position'));
         $qb2->orderBy('n.name', 'ASC');
         $result2 = $qb2->getQuery()->getResult();
@@ -54,7 +54,7 @@ class CountryController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $country = $em->getRepository("ErsBase\Entity\Country")->findOneBy(array('id' => $id));
+        $country = $em->getRepository('ErsBase\Entity\Country')->findOneBy(array('id' => $id));
 
         $form  = new Form\Country();
         $form->bind($country);
@@ -109,7 +109,7 @@ class CountryController extends AbstractActionController {
             if ($del == 'Yes') {
                 
                 $id = (int) $request->getPost('id');
-                $tax = $em->getRepository("ErsBase\Entity\Tax")
+                $tax = $em->getRepository('ErsBase\Entity\Tax')
                         ->findOneBy(array('id' => $id));
                 $em->remove($tax);
                 $em->flush();
@@ -120,7 +120,7 @@ class CountryController extends AbstractActionController {
 
         return new ViewModel(array(
             'id'    => $id,
-            'tax' => $tax = $em->getRepository("ErsBase\Entity\Tax")
+            'tax' => $tax = $em->getRepository('ErsBase\Entity\Tax')
                 ->findOneBy(array('id' => $id)),
             'breadcrumb' => $breadcrumb,
         ));

--- a/module/Admin/src/Admin/Controller/CronController.php
+++ b/module/Admin/src/Admin/Controller/CronController.php
@@ -31,14 +31,14 @@ class CronController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $orderStatus = $em->getRepository("ErsBase\Entity\OrderStatus")
+        $orderStatus = $em->getRepository('ErsBase\Entity\OrderStatus')
                 ->findBy(array('value' => 'cron'));
         foreach($orderStatus as $status) {
             $em->remove($status);
         }
         $em->flush();
         
-        $orders = $em->getRepository("ErsBase\Entity\Order")
+        $orders = $em->getRepository('ErsBase\Entity\Order')
                 ->findBy(array(), array('created' => 'DESC'));
         
         $logger = $this->getServiceLocator()->get('Logger');
@@ -78,7 +78,7 @@ class CronController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $statements = $em->getRepository("ErsBase\Entity\BankStatement")
+        $statements = $em->getRepository('ErsBase\Entity\BankStatement')
                 ->findAll();
         
         $longest_match = 0;
@@ -103,7 +103,7 @@ class CronController extends AbstractActionController {
             if(is_array($ret)) {
                 $found = false;
                 foreach($ret as $code) {
-                    $order_code = $em->getRepository("ErsBase\Entity\Code")
+                    $order_code = $em->getRepository('ErsBase\Entity\Code')
                         ->findOneBy(array('value' => $code->getValue()));
                     if($order_code) {
                         $found = true;
@@ -115,7 +115,7 @@ class CronController extends AbstractActionController {
                     if(is_array($ret)) {
                         $found = false;
                         foreach($ret as $code) {
-                            $order_code = $em->getRepository("ErsBase\Entity\Code")
+                            $order_code = $em->getRepository('ErsBase\Entity\Code')
                                 ->findOneBy(array('value' => $code->getValue()));
                             if($order_code) {
                                 $found = true;
@@ -142,7 +142,7 @@ class CronController extends AbstractActionController {
          */
         
         #TODO: find order which contain items in status != paid and != cancelled and != refund
-        $orders = $em->getRepository("ErsBase\Entity\Order")
+        $orders = $em->getRepository('ErsBase\Entity\Order')
                 ->findBy(array('payment_status' => 'unpaid'));
         foreach($orders as $order) {
             $statement_amount = $order->getStatementAmount();
@@ -187,7 +187,7 @@ class CronController extends AbstractActionController {
         $bankaccount = $statement->getBankAccount();
         #$statement_format = json_decode($bankaccount->getStatementFormat());
         
-        $order = $em->getRepository("ErsBase\Entity\Order")
+        $order = $em->getRepository('ErsBase\Entity\Order')
             ->findOneBy(array('Code_id' => $code->getId()));
         
         $statement->setStatus('matched');
@@ -203,7 +203,7 @@ class CronController extends AbstractActionController {
         /*
          * set andi as admin for auto-matching
          */
-        $admin = $em->getRepository("ErsBase\Entity\User")
+        $admin = $em->getRepository('ErsBase\Entity\User')
             ->findOneBy(array('id' => 1));
         $match->setAdmin($admin);
         
@@ -327,7 +327,7 @@ class CronController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $matches = $em->getRepository("ErsBase\Entity\Match")
+        $matches = $em->getRepository('ErsBase\Entity\Match')
                 ->findAll();
         
         foreach($matches as $match) {
@@ -343,7 +343,7 @@ class CronController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $users = $em->getRepository("ErsBase\Entity\User")
+        $users = $em->getRepository('ErsBase\Entity\User')
                 ->findAll();
         
         $fp = fopen('/tmp/users.csv', 'w');
@@ -368,12 +368,12 @@ class CronController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        #$order = $em->getRepository("ErsBase\Entity\Order")
+        #$order = $em->getRepository('ErsBase\Entity\Order')
                 #->findOneBy(array('id' => '297'));
                 #->findOneBy(array('id' => '12'));
                 #->findOneBy(array('id' => '54'));
         
-        $orders = $em->getRepository("ErsBase\Entity\Order")
+        $orders = $em->getRepository('ErsBase\Entity\Order')
                 ->findAll();
         $count = 0;
         $eticketService = $this->getServiceLocator()
@@ -398,7 +398,7 @@ class CronController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $orders = $em->getRepository("ErsBase\Entity\Order")
+        $orders = $em->getRepository('ErsBase\Entity\Order')
                 ->findAll();
         $count = 0;
         foreach($orders as $order) {
@@ -422,7 +422,7 @@ class CronController extends AbstractActionController {
             ->get('Doctrine\ORM\EntityManager');
         
         # find user under 18
-        $qb = $em->getRepository("ErsBase\Entity\User")->createQueryBuilder('u');
+        $qb = $em->getRepository('ErsBase\Entity\User')->createQueryBuilder('u');
         $qb->where("u.birthday > '1998-07-30'");
         $users = $qb->getQuery()->getResult();
         echo "found ".count($users)." users under 18.".PHP_EOL;
@@ -517,7 +517,7 @@ class CronController extends AbstractActionController {
             ->get('Doctrine\ORM\EntityManager');
         
         # correct package ticket_status
-        $qb = $em->getRepository("ErsBase\Entity\Package")->createQueryBuilder('p');
+        $qb = $em->getRepository('ErsBase\Entity\Package')->createQueryBuilder('p');
         $qb->where('p.ticket_status IS NULL');
         $qb->orWhere("p.ticket_status = 'not_send'");
         $noStatusPackages = $qb->getQuery()->getResult();
@@ -560,7 +560,7 @@ class CronController extends AbstractActionController {
         }
         $em->flush();
         
-        $packages = $em->getRepository("ErsBase\Entity\Package")
+        $packages = $em->getRepository('ErsBase\Entity\Package')
             ->findBy(array('ticket_status' => 'can_send'), array(), 100);
         echo "Can send out e-tickets for ".count($packages)." packages.".PHP_EOL;
         
@@ -644,7 +644,7 @@ class CronController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $users = $em->getRepository("ErsBase\Entity\User")
+        $users = $em->getRepository('ErsBase\Entity\User')
                 ->findAll();
         
         echo "checking ".count($users)." emails".PHP_EOL;
@@ -716,10 +716,10 @@ class CronController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $qb = $em->getRepository("ErsBase\Entity\Item")->createQueryBuilder('i');
+        $qb = $em->getRepository('ErsBase\Entity\Item')->createQueryBuilder('i');
         $qb->where('i.agegroup IS NULL');
         $items = $qb->getQuery()->getResult();
-        /*$items = $em->getRepository("ErsBase\Entity\Item")
+        /*$items = $em->getRepository('ErsBase\Entity\Item')
                 ->findAll();*/
         
         echo "checking ".count($items)." items".PHP_EOL;
@@ -778,7 +778,7 @@ class CronController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $qb = $em->getRepository("ErsBase\Entity\Item")->createQueryBuilder('i');
+        $qb = $em->getRepository('ErsBase\Entity\Item')->createQueryBuilder('i');
         $qb->where("i.status = 'transferred'");
         #$qb->orWhere("p.ticket_status = 'not_send'");
         $transferred_items = $qb->getQuery()->getResult();
@@ -812,7 +812,7 @@ class CronController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $qb = $em->getRepository("ErsBase\Entity\Order")->createQueryBuilder('o');
+        $qb = $em->getRepository('ErsBase\Entity\Order')->createQueryBuilder('o');
         $qb->join('o.status', 's');
         $qb->where('s.value', ':status');
         $qb->setParameter('status', 'order pending');

--- a/module/Admin/src/Admin/Controller/DeadlineController.php
+++ b/module/Admin/src/Admin/Controller/DeadlineController.php
@@ -21,7 +21,7 @@ class DeadlineController extends AbstractActionController {
             ->get('Doctrine\ORM\EntityManager');
         
         return new ViewModel(array(
-            'deadlines' => $em->getRepository("ErsBase\Entity\Deadline")
+            'deadlines' => $em->getRepository('ErsBase\Entity\Deadline')
                 ->findBy(array(), array('deadline' => 'ASC')),
          ));
     }
@@ -68,7 +68,7 @@ class DeadlineController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $deadline = $em->getRepository("ErsBase\Entity\Deadline")->findOneBy(array('id' => $id));
+        $deadline = $em->getRepository('ErsBase\Entity\Deadline')->findOneBy(array('id' => $id));
 
         $form = new Form\Deadline();
         $form->bind($deadline);
@@ -101,11 +101,11 @@ class DeadlineController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $deadline = $em->getRepository("ErsBase\Entity\Deadline")
+        $deadline = $em->getRepository('ErsBase\Entity\Deadline')
                 ->findOneBy(array('id' => $id));
         $productprices = $deadline->getProductPrices();
         
-        $qb = $em->getRepository("ErsBase\Entity\PaymentType")->createQueryBuilder('n');
+        $qb = $em->getRepository('ErsBase\Entity\PaymentType')->createQueryBuilder('n');
         $paymenttypes = $qb->where(
                 $qb->expr()->orX(
                     $qb->expr()->eq('n.active_from_id', $id),
@@ -118,7 +118,7 @@ class DeadlineController extends AbstractActionController {
 
             if ($del == 'Yes') {
                 $id = (int) $request->getPost('id');
-                $deadline = $em->getRepository("ErsBase\Entity\Deadline")
+                $deadline = $em->getRepository('ErsBase\Entity\Deadline')
                     ->findOneBy(array('id' => $id));
                 $em->remove($deadline);
                 $em->flush();

--- a/module/Admin/src/Admin/Controller/ItemController.php
+++ b/module/Admin/src/Admin/Controller/ItemController.php
@@ -22,7 +22,7 @@ class ItemController extends AbstractActionController {
             ->get('Doctrine\ORM\EntityManager');
         
         return new ViewModel(array(
-            'agegroups' => $em->getRepository("ErsBase\Entity\Agegroup")
+            'agegroups' => $em->getRepository('ErsBase\Entity\Agegroup')
                 ->findBy(array(), array('agegroup' => 'ASC')),
         ));
     }
@@ -36,7 +36,7 @@ class ItemController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $package = $em->getRepository("ErsBase\Entity\Package")
+        $package = $em->getRepository('ErsBase\Entity\Package')
                 ->findOneBy(array('id' => $id));
         
         return new ViewModel(array(
@@ -58,7 +58,7 @@ class ItemController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $item = $em->getRepository("ErsBase\Entity\Item")
+        $item = $em->getRepository('ErsBase\Entity\Item')
                 ->findOneBy(array('id' => $id));
         
         $forrest = new Service\BreadcrumbService();
@@ -73,7 +73,7 @@ class ItemController extends AbstractActionController {
             if ($ret == 'Yes') {
                 $id = (int) $request->getPost('id');
                 
-                $item = $em->getRepository("ErsBase\Entity\Item")
+                $item = $em->getRepository('ErsBase\Entity\Item')
                     ->findOneBy(array('id' => $id));
                 
                 $item->setStatus('ordered');
@@ -99,7 +99,7 @@ class ItemController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $item = $em->getRepository("ErsBase\Entity\Item")
+        $item = $em->getRepository('ErsBase\Entity\Item')
                 ->findOneBy(array('id' => $id));
         
         $forrest = new Service\BreadcrumbService();
@@ -114,7 +114,7 @@ class ItemController extends AbstractActionController {
             if ($ret == 'Yes') {
                 $id = (int) $request->getPost('id');
                 
-                $item = $em->getRepository("ErsBase\Entity\Item")
+                $item = $em->getRepository('ErsBase\Entity\Item')
                     ->findOneBy(array('id' => $id));
                 
                 $item->setStatus('cancelled');
@@ -144,7 +144,7 @@ class ItemController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $item = $em->getRepository("ErsBase\Entity\Item")
+        $item = $em->getRepository('ErsBase\Entity\Item')
                 ->findOneBy(array('id' => $id));
         
         $forrest = new Service\BreadcrumbService();
@@ -159,7 +159,7 @@ class ItemController extends AbstractActionController {
             if ($ret == 'Yes') {
                 $id = (int) $request->getPost('id');
                 
-                $item = $em->getRepository("ErsBase\Entity\Item")
+                $item = $em->getRepository('ErsBase\Entity\Item')
                     ->findOneBy(array('id' => $id));
                 
                 $item->setStatus('ordered');
@@ -185,7 +185,7 @@ class ItemController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $item = $em->getRepository("ErsBase\Entity\Item")
+        $item = $em->getRepository('ErsBase\Entity\Item')
                 ->findOneBy(array('id' => $id));
         
         $forrest = new Service\BreadcrumbService();
@@ -200,7 +200,7 @@ class ItemController extends AbstractActionController {
             if ($ret == 'Yes') {
                 $id = (int) $request->getPost('id');
                 
-                $item = $em->getRepository("ErsBase\Entity\Item")
+                $item = $em->getRepository('ErsBase\Entity\Item')
                     ->findOneBy(array('id' => $id));
                 
                 $item->setStatus('refund');
@@ -230,7 +230,7 @@ class ItemController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $item = $em->getRepository("ErsBase\Entity\Item")
+        $item = $em->getRepository('ErsBase\Entity\Item')
                 ->findOneBy(array('id' => $id));
         
         $forrest = new Service\BreadcrumbService();
@@ -245,7 +245,7 @@ class ItemController extends AbstractActionController {
             if ($ret == 'Yes') {
                 $id = (int) $request->getPost('id');
                 
-                $item = $em->getRepository("ErsBase\Entity\Item")
+                $item = $em->getRepository('ErsBase\Entity\Item')
                     ->findOneBy(array('id' => $id));
                 
                 $item->setStatus('ordered');
@@ -274,7 +274,7 @@ class ItemController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $item = $em->getRepository("ErsBase\Entity\Item")
+        $item = $em->getRepository('ErsBase\Entity\Item')
                 ->findOneBy(array('id' => $id));
         
         $forrest = new Service\BreadcrumbService();
@@ -289,7 +289,7 @@ class ItemController extends AbstractActionController {
             if ($ret == 'Yes') {
                 $id = (int) $request->getPost('id');
                 
-                $item = $em->getRepository("ErsBase\Entity\Item")
+                $item = $em->getRepository('ErsBase\Entity\Item')
                     ->findOneBy(array('id' => $id));
                 
                 $item->setStatus('zero_ok');
@@ -315,7 +315,7 @@ class ItemController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $item = $em->getRepository("ErsBase\Entity\Item")
+        $item = $em->getRepository('ErsBase\Entity\Item')
                 ->findOneBy(array('id' => $id));
         
         $forrest = new Service\BreadcrumbService();
@@ -330,7 +330,7 @@ class ItemController extends AbstractActionController {
             if ($ret == 'Yes') {
                 $id = (int) $request->getPost('id');
                 
-                $item = $em->getRepository("ErsBase\Entity\Item")
+                $item = $em->getRepository('ErsBase\Entity\Item')
                     ->findOneBy(array('id' => $id));
                 
                 $item->setStatus('ordered');
@@ -356,7 +356,7 @@ class ItemController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $item = $em->getRepository("ErsBase\Entity\Item")
+        $item = $em->getRepository('ErsBase\Entity\Item')
                 ->findOneBy(array('id' => $id));
         
         $forrest = new Service\BreadcrumbService();
@@ -371,7 +371,7 @@ class ItemController extends AbstractActionController {
             if ($ret == 'Yes') {
                 $id = (int) $request->getPost('id');
                 
-                $item = $em->getRepository("ErsBase\Entity\Item")
+                $item = $em->getRepository('ErsBase\Entity\Item')
                     ->findOneBy(array('id' => $id));
                 
                 $item->setStatus('paid');
@@ -397,7 +397,7 @@ class ItemController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $item = $em->getRepository("ErsBase\Entity\Item")
+        $item = $em->getRepository('ErsBase\Entity\Item')
                 ->findOneBy(array('id' => $id));
         
         $form = new Form\SearchPackage();
@@ -508,10 +508,10 @@ class ItemController extends AbstractActionController {
 
             if ($form->isValid()) {
                 $data = $form->getData();
-                $user = $em->getRepository("ErsBase\Entity\User")
+                $user = $em->getRepository('ErsBase\Entity\User')
                     ->findOneBy(array('id' => $data['user_id']));
                 
-                $item = $em->getRepository("ErsBase\Entity\Item")
+                $item = $em->getRepository('ErsBase\Entity\Item')
                     ->findOneBy(array('id' => $data['item_id']));
                 
                 $log = new Entity\Log();
@@ -529,7 +529,7 @@ class ItemController extends AbstractActionController {
                 $codecheck = 1;
                 while($codecheck != null) {
                     $code->genCode();
-                    $codecheck = $em->getRepository("ErsBase\Entity\Code")
+                    $codecheck = $em->getRepository('ErsBase\Entity\Code')
                         ->findOneBy(array('value' => $code->getValue()));
                 }
                 $newPackage->setCode($code);
@@ -553,7 +553,7 @@ class ItemController extends AbstractActionController {
                 $codecheck = 1;
                 while($codecheck != null) {
                     $code->genCode();
-                    $codecheck = $em->getRepository("ErsBase\Entity\Code")
+                    $codecheck = $em->getRepository('ErsBase\Entity\Code')
                         ->findOneBy(array('value' => $code->getValue()));
                 }
                 $newItem->setCode($code);
@@ -581,13 +581,13 @@ class ItemController extends AbstractActionController {
         
         $user = null;
         if($user_id != 0) {
-            $user = $em->getRepository("ErsBase\Entity\User")
+            $user = $em->getRepository('ErsBase\Entity\User')
                     ->findOneBy(array('id' => $user_id));
         }
         
         $item = null;
         if($item_id != 0) {
-            $item = $em->getRepository("ErsBase\Entity\Item")
+            $item = $em->getRepository('ErsBase\Entity\Item')
                     ->findOneBy(array('id' => $item_id));
         }
         

--- a/module/Admin/src/Admin/Controller/MatchingController.php
+++ b/module/Admin/src/Admin/Controller/MatchingController.php
@@ -27,10 +27,10 @@ class MatchingController extends AbstractActionController {
         $limit = 50;
         $offset = ($limit * ($page - 1));
         # findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
-        $matchings = $em->getRepository("ErsBase\Entity\Match")
+        $matchings = $em->getRepository('ErsBase\Entity\Match')
                 ->findBy(array('status' => 'active'), array('updated' => 'DESC'), $limit, $offset);
         
-        $qb = $em->getRepository("ErsBase\Entity\Match")->createQueryBuilder('m');
+        $qb = $em->getRepository('ErsBase\Entity\Match')->createQueryBuilder('m');
         $qb->select('count(m.id)');
         $count = $qb->getQuery()->getSingleScalarResult();
         $pagecount = floor($count/$limit);
@@ -62,10 +62,10 @@ class MatchingController extends AbstractActionController {
          * TODO: Add filter to select status of orders. unpaid is the default 
          * status but underpaid would be nice, too.
          */
-        $orders = $em->getRepository("ErsBase\Entity\Order")
+        $orders = $em->getRepository('ErsBase\Entity\Order')
                 ->findBy(array('payment_status' => 'unpaid'));
         
-        #$repository = $em->getRepository("ErsBase\Entity\Order");
+        #$repository = $em->getRepository('ErsBase\Entity\Order');
 
         #$qb = $repository->createQueryBuilder('o');
         #$qb->leftJoin('o.matches', 'm');
@@ -87,13 +87,13 @@ class MatchingController extends AbstractActionController {
         /*
          * add bankaccounts to view model
          */
-        $bankaccounts = $em->getRepository("ErsBase\Entity\BankAccount")
+        $bankaccounts = $em->getRepository('ErsBase\Entity\BankAccount')
             ->findBy(array());
         
         /*
          * add bank statements to as value options to form
          */
-        $statements = $em->getRepository("ErsBase\Entity\BankStatement")
+        $statements = $em->getRepository('ErsBase\Entity\BankStatement')
                 ->findAll();
         $statement_options = array();
         foreach($statements as $statement) {
@@ -121,7 +121,7 @@ class MatchingController extends AbstractActionController {
                  */
                 $orders = array();
                 foreach($data['orders'] as $order_id) {
-                    $orders[] = $em->getRepository("ErsBase\Entity\Order")
+                    $orders[] = $em->getRepository('ErsBase\Entity\Order')
                         ->findBy(array('id' => $order_id));
                 }
                 
@@ -130,7 +130,7 @@ class MatchingController extends AbstractActionController {
                  */
                 $statements = array();
                 foreach($data['statements'] as $statement_id) {
-                    $statements[] = $em->getRepository("ErsBase\Entity\BankStatement")
+                    $statements[] = $em->getRepository('ErsBase\Entity\BankStatement')
                         ->findBy(array('id' => $statement_id));
                 }
                 
@@ -183,7 +183,7 @@ class MatchingController extends AbstractActionController {
         $orders = array();
         $order_options = array();
         foreach($param_orders as $order_id) {
-            $orders[] = $em->getRepository("ErsBase\Entity\Order")
+            $orders[] = $em->getRepository('ErsBase\Entity\Order')
                 ->findOneBy(array('id' => $order_id));
             $order_options[] = array(
                 'label' => $order_id,
@@ -196,7 +196,7 @@ class MatchingController extends AbstractActionController {
         $statements = array();
         $statement_options = array();
         foreach($param_statements as $statement_id) {
-            $statements[] = $em->getRepository("ErsBase\Entity\BankStatement")
+            $statements[] = $em->getRepository('ErsBase\Entity\BankStatement')
                 ->findOneBy(array('id' => $statement_id));
             $statement_options[] = array(
                 'label' => $statement_id,
@@ -228,7 +228,7 @@ class MatchingController extends AbstractActionController {
                  */
                 $orders = array();
                 foreach($data['Order_id'] as $order_id) {
-                    $orders[] = $em->getRepository("ErsBase\Entity\Order")
+                    $orders[] = $em->getRepository('ErsBase\Entity\Order')
                         ->findOneBy(array('id' => $order_id));
                 }
                 
@@ -245,7 +245,7 @@ class MatchingController extends AbstractActionController {
                  */
                 $statements = array();
                 foreach($data['BankStatement_id'] as $statement_id) {
-                    $statements[] = $em->getRepository("ErsBase\Entity\BankStatement")
+                    $statements[] = $em->getRepository('ErsBase\Entity\BankStatement')
                         ->findOneBy(array('id' => $statement_id));
                 }
                 
@@ -319,7 +319,7 @@ class MatchingController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $match = $em->getRepository("ErsBase\Entity\Match")
+        $match = $em->getRepository('ErsBase\Entity\Match')
                 ->findOneBy(array('id' => $id));
         
         $request = $this->getRequest();
@@ -329,7 +329,7 @@ class MatchingController extends AbstractActionController {
             if ($ret == 'Yes') {
                 $id = (int) $request->getPost('id');
                 
-                $match = $em->getRepository("ErsBase\Entity\Match")
+                $match = $em->getRepository('ErsBase\Entity\Match')
                     ->findOneBy(array('id' => $id));
                 
                 $match->setStatus('disabled');
@@ -367,7 +367,7 @@ class MatchingController extends AbstractActionController {
         $forrest = new Service\BreadcrumbService();
         $forrest->set('matching', 'admin/matching', array('action' => 'disable'));
         
-        $statements = $em->getRepository("ErsBase\Entity\BankStatement")
+        $statements = $em->getRepository('ErsBase\Entity\BankStatement')
                 ->findBy(array('status' => 'disabled'), array('updated' => 'DESC'));
         
         return new ViewModel(array(
@@ -382,7 +382,7 @@ class MatchingController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $statement = $em->getRepository("ErsBase\Entity\BankStatement")
+        $statement = $em->getRepository('ErsBase\Entity\BankStatement')
                 ->findOneBy(array('id' => $id));
         
         $forrest = new Service\BreadcrumbService();
@@ -397,7 +397,7 @@ class MatchingController extends AbstractActionController {
             if ($ret == 'Yes') {
                 $id = (int) $request->getPost('id');
                 
-                $statement = $em->getRepository("ErsBase\Entity\BankStatement")
+                $statement = $em->getRepository('ErsBase\Entity\BankStatement')
                     ->findOneBy(array('id' => $id));
                 
                 $statement->setStatus('disabled');
@@ -422,7 +422,7 @@ class MatchingController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $statement = $em->getRepository("ErsBase\Entity\BankStatement")
+        $statement = $em->getRepository('ErsBase\Entity\BankStatement')
                 ->findOneBy(array('id' => $id));
         
         $forrest = new Service\BreadcrumbService();
@@ -437,7 +437,7 @@ class MatchingController extends AbstractActionController {
             if ($ret == 'Yes') {
                 $id = (int) $request->getPost('id');
                 
-                $statement = $em->getRepository("ErsBase\Entity\BankStatement")
+                $statement = $em->getRepository('ErsBase\Entity\BankStatement')
                     ->findOneBy(array('id' => $id));
                 
                 $statement->setStatus('new');

--- a/module/Admin/src/Admin/Controller/OrderController.php
+++ b/module/Admin/src/Admin/Controller/OrderController.php
@@ -22,7 +22,7 @@ class OrderController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $orders = $em->getRepository("ErsBase\Entity\Order")
+        $orders = $em->getRepository('ErsBase\Entity\Order')
                 ->findBy(array(), array('created' => 'DESC'));
         
         return new ViewModel(array(
@@ -91,7 +91,7 @@ class OrderController extends AbstractActionController {
             /*
              * search code
              */
-            $qb = $em->getRepository("ErsBase\Entity\Order")->createQueryBuilder('o');
+            $qb = $em->getRepository('ErsBase\Entity\Order')->createQueryBuilder('o');
             $qb->join('o.code', 'oc');
             $qb->join('o.packages', 'p');
             $qb->join('p.code', 'pc');
@@ -134,7 +134,7 @@ class OrderController extends AbstractActionController {
              * search firstname, surname, email, birthdate
              * of buyer and participant
              */
-            $qb = $em->getRepository("ErsBase\Entity\Order")->createQueryBuilder('o');
+            $qb = $em->getRepository('ErsBase\Entity\Order')->createQueryBuilder('o');
             $qb->join('o.buyer', 'b');
             $qb->join('o.packages', 'p');
             $qb->join('p.participant', 'u');
@@ -175,9 +175,9 @@ class OrderController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $order = $em->getRepository("ErsBase\Entity\Order")
+        $order = $em->getRepository('ErsBase\Entity\Order')
                 ->findOneBy(array('id' => $id));
-        $paymentDetails = $em->getRepository("ErsBase\Entity\PaymentDetail")
+        $paymentDetails = $em->getRepository('ErsBase\Entity\PaymentDetail')
                 ->findBy(array('order_id' => $id), array('created' => 'DESC'));
         
         $forrest = new Service\BreadcrumbService();
@@ -199,10 +199,10 @@ class OrderController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $order = $em->getRepository("ErsBase\Entity\Order")
+        $order = $em->getRepository('ErsBase\Entity\Order')
                 ->findOneBy(array('id' => $id));
         
-        $paymenttypes = $em->getRepository("ErsBase\Entity\PaymentType")
+        $paymenttypes = $em->getRepository('ErsBase\Entity\PaymentType')
                 ->findBy(array(), array('position' => 'ASC'));
         $types = array();
         $now = new \DateTime();
@@ -249,7 +249,7 @@ class OrderController extends AbstractActionController {
             if ($form->isValid()) {
                 $data = $form->getData();
                 
-                $paymenttype = $em->getRepository("ErsBase\Entity\PaymentType")
+                $paymenttype = $em->getRepository('ErsBase\Entity\PaymentType')
                         ->findOneBy(array('id' => $data['paymenttype_id']));
                 
                 $logger->info($paymenttype->getName());
@@ -284,7 +284,7 @@ class OrderController extends AbstractActionController {
         
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $order = $em->getRepository("ErsBase\Entity\Order")
+        $order = $em->getRepository('ErsBase\Entity\Order')
                 ->findOneBy(array('id' => $id));
         
         $forrest = new Service\BreadcrumbService();
@@ -299,7 +299,7 @@ class OrderController extends AbstractActionController {
             if ($ret == 'Yes') {
                 $id = (int) $request->getPost('id');
                 
-                $order = $em->getRepository("ErsBase\Entity\Order")
+                $order = $em->getRepository('ErsBase\Entity\Order')
                     ->findOneBy(array('id' => $id));
                 
                 $emailService = $this->getServiceLocator()
@@ -328,7 +328,7 @@ class OrderController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $order = $em->getRepository("ErsBase\Entity\Order")
+        $order = $em->getRepository('ErsBase\Entity\Order')
                 ->findOneBy(array('id' => $id));
         
         $forrest = new Service\BreadcrumbService();
@@ -343,7 +343,7 @@ class OrderController extends AbstractActionController {
             if ($ret == 'Yes') {
                 $id = (int) $request->getPost('id');
                 
-                $order = $em->getRepository("ErsBase\Entity\Order")
+                $order = $em->getRepository('ErsBase\Entity\Order')
                     ->findOneBy(array('id' => $id));
                 
                 if($order->getPaymentStatus() != 'paid') {
@@ -431,7 +431,7 @@ class OrderController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $order = $em->getRepository("ErsBase\Entity\Order")
+        $order = $em->getRepository('ErsBase\Entity\Order')
                 ->findOneBy(array('id' => $id));
         
         $forrest = new Service\BreadcrumbService();
@@ -446,7 +446,7 @@ class OrderController extends AbstractActionController {
             if ($ret == 'Yes') {
                 $id = (int) $request->getPost('id');
                 
-                $order = $em->getRepository("ErsBase\Entity\Order")
+                $order = $em->getRepository('ErsBase\Entity\Order')
                     ->findOneBy(array('id' => $id));
                 
                 # prepare email (participant, buyer)
@@ -494,7 +494,7 @@ class OrderController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $order = $em->getRepository("ErsBase\Entity\Order")
+        $order = $em->getRepository('ErsBase\Entity\Order')
                 ->findOneBy(array('id' => $id));
         
         $form = new Form\SearchUser();
@@ -607,10 +607,10 @@ class OrderController extends AbstractActionController {
 
             if ($form->isValid()) {
                 $data = $form->getData();
-                $user = $em->getRepository("ErsBase\Entity\User")
+                $user = $em->getRepository('ErsBase\Entity\User')
                     ->findOneBy(array('id' => $data['user_id']));
                 
-                $order = $em->getRepository("ErsBase\Entity\Order")
+                $order = $em->getRepository('ErsBase\Entity\Order')
                     ->findOneBy(array('id' => $data['order_id']));
                 
                 $log = new Entity\Log();
@@ -634,13 +634,13 @@ class OrderController extends AbstractActionController {
         
         $user = null;
         if($user_id != 0) {
-            $user = $em->getRepository("ErsBase\Entity\User")
+            $user = $em->getRepository('ErsBase\Entity\User')
                     ->findOneBy(array('id' => $user_id));
         }
         
         $order = null;
         if($order_id != 0) {
-            $order = $em->getRepository("ErsBase\Entity\Order")
+            $order = $em->getRepository('ErsBase\Entity\Order')
                     ->findOneBy(array('id' => $order_id));
         }
         
@@ -667,7 +667,7 @@ class OrderController extends AbstractActionController {
         
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $package = $em->getRepository("ErsBase\Entity\Package")
+        $package = $em->getRepository('ErsBase\Entity\Package')
                 ->findOneBy(array('id' => $id));
         
         return new ViewModel(array(
@@ -680,7 +680,7 @@ class OrderController extends AbstractActionController {
         
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $item = $em->getRepository("ErsBase\Entity\Item")
+        $item = $em->getRepository('ErsBase\Entity\Item')
                 ->findOneBy(array('id' => $id));
         
         return new ViewModel(array(
@@ -695,7 +695,7 @@ class OrderController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $order = $em->getRepository("ErsBase\Entity\Order")
+        $order = $em->getRepository('ErsBase\Entity\Order')
                 ->findOneBy(array('id' => $id));
         
         $forrest = new Service\BreadcrumbService();
@@ -710,7 +710,7 @@ class OrderController extends AbstractActionController {
             if ($ret == 'Yes') {
                 $id = (int) $request->getPost('id');
                 
-                $order = $em->getRepository("ErsBase\Entity\Order")
+                $order = $em->getRepository('ErsBase\Entity\Order')
                     ->findOneBy(array('id' => $id));
                 
                 $order->setPaymentStatus('cancelled');
@@ -741,7 +741,7 @@ class OrderController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $order = $em->getRepository("ErsBase\Entity\Order")
+        $order = $em->getRepository('ErsBase\Entity\Order')
                 ->findOneBy(array('id' => $id));
         
         $forrest = new Service\BreadcrumbService();
@@ -756,7 +756,7 @@ class OrderController extends AbstractActionController {
             if ($ret == 'Yes') {
                 $id = (int) $request->getPost('id');
                 
-                $order = $em->getRepository("ErsBase\Entity\Order")
+                $order = $em->getRepository('ErsBase\Entity\Order')
                     ->findOneBy(array('id' => $id));
                 
                 $order->setPaymentStatus('paid');
@@ -787,7 +787,7 @@ class OrderController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $order = $em->getRepository("ErsBase\Entity\Order")
+        $order = $em->getRepository('ErsBase\Entity\Order')
                 ->findOneBy(array('id' => $id));
         
         $forrest = new Service\BreadcrumbService();
@@ -802,7 +802,7 @@ class OrderController extends AbstractActionController {
             if ($ret == 'Yes') {
                 $id = (int) $request->getPost('id');
                 
-                $order = $em->getRepository("ErsBase\Entity\Order")
+                $order = $em->getRepository('ErsBase\Entity\Order')
                     ->findOneBy(array('id' => $id));
                 
                 $order->setPaymentStatus('refund');
@@ -833,7 +833,7 @@ class OrderController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $order = $em->getRepository("ErsBase\Entity\Order")
+        $order = $em->getRepository('ErsBase\Entity\Order')
                 ->findOneBy(array('id' => $id));
         
         $forrest = new Service\BreadcrumbService();
@@ -848,7 +848,7 @@ class OrderController extends AbstractActionController {
             if ($ret == 'Yes') {
                 $id = (int) $request->getPost('id');
                 
-                $order = $em->getRepository("ErsBase\Entity\Order")
+                $order = $em->getRepository('ErsBase\Entity\Order')
                     ->findOneBy(array('id' => $id));
                 
                 $order->setPaymentStatus('unpaid');
@@ -876,7 +876,7 @@ class OrderController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $repository = $em->getRepository("ErsBase\Entity\Order");
+        $repository = $em->getRepository('ErsBase\Entity\Order');
 
         $qb = $repository->createQueryBuilder('o')
                 ->select('o')

--- a/module/Admin/src/Admin/Controller/OverviewController.php
+++ b/module/Admin/src/Admin/Controller/OverviewController.php
@@ -32,13 +32,13 @@ class OverviewController extends AbstractActionController {
         $breadcrumbService->set('product', 'admin/overview/config');
         
         return new ViewModel(array(
-            'taxes' => $em->getRepository("ErsBase\Entity\Tax")->findAll(),
-            'deadlines' => $em->getRepository("ErsBase\Entity\Deadline")->findAll(),
-            'agegroups' => $em->getRepository("ErsBase\Entity\Agegroup")->findAll(),
-            'paymenttypes' => $em->getRepository("ErsBase\Entity\PaymentType")->findAll(),
-            'counters' => $em->getRepository("ErsBase\Entity\Counter")->findAll(),
-            'statuses' => $em->getRepository("ErsBase\Entity\Status")->findAll(),
-            'products' => $em->getRepository("ErsBase\Entity\Product")->findAll(),
+            'taxes' => $em->getRepository('ErsBase\Entity\Tax')->findAll(),
+            'deadlines' => $em->getRepository('ErsBase\Entity\Deadline')->findAll(),
+            'agegroups' => $em->getRepository('ErsBase\Entity\Agegroup')->findAll(),
+            'paymenttypes' => $em->getRepository('ErsBase\Entity\PaymentType')->findAll(),
+            'counters' => $em->getRepository('ErsBase\Entity\Counter')->findAll(),
+            'statuses' => $em->getRepository('ErsBase\Entity\Status')->findAll(),
+            'products' => $em->getRepository('ErsBase\Entity\Product')->findAll(),
         ));
     }
 }

--- a/module/Admin/src/Admin/Controller/PackageController.php
+++ b/module/Admin/src/Admin/Controller/PackageController.php
@@ -23,7 +23,7 @@ class PackageController extends AbstractActionController {
             ->get('Doctrine\ORM\EntityManager');
         
         return new ViewModel(array(
-            'agegroups' => $em->getRepository("ErsBase\Entity\Agegroup")
+            'agegroups' => $em->getRepository('ErsBase\Entity\Agegroup')
                 ->findBy(array(), array('agegroup' => 'ASC')),
         ));
     }
@@ -43,7 +43,7 @@ class PackageController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $package = $em->getRepository("ErsBase\Entity\Package")
+        $package = $em->getRepository('ErsBase\Entity\Package')
                 ->findOneBy(array('id' => $id));
         
         return new ViewModel(array(
@@ -58,7 +58,7 @@ class PackageController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $package = $em->getRepository("ErsBase\Entity\Package")
+        $package = $em->getRepository('ErsBase\Entity\Package')
                 ->findOneBy(array('id' => $id));
         
         $forrest = new Service\BreadcrumbService();
@@ -73,7 +73,7 @@ class PackageController extends AbstractActionController {
             if ($ret == 'Yes') {
                 $id = (int) $request->getPost('id');
                 
-                $package = $em->getRepository("ErsBase\Entity\Package")
+                $package = $em->getRepository('ErsBase\Entity\Package')
                     ->findOneBy(array('id' => $id));
                 
                 foreach($package->getItems() as $item) {
@@ -101,7 +101,7 @@ class PackageController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $package = $em->getRepository("ErsBase\Entity\Package")
+        $package = $em->getRepository('ErsBase\Entity\Package')
                 ->findOneBy(array('id' => $id));
         
         $forrest = new Service\BreadcrumbService();
@@ -116,7 +116,7 @@ class PackageController extends AbstractActionController {
             if ($ret == 'Yes') {
                 $id = (int) $request->getPost('id');
                 
-                $package = $em->getRepository("ErsBase\Entity\Package")
+                $package = $em->getRepository('ErsBase\Entity\Package')
                     ->findOneBy(array('id' => $id));
                 
                 foreach($package->getItems() as $item) {
@@ -144,7 +144,7 @@ class PackageController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $package = $em->getRepository("ErsBase\Entity\Package")
+        $package = $em->getRepository('ErsBase\Entity\Package')
                 ->findOneBy(array('id' => $id));
         
         $forrest = new Service\BreadcrumbService();
@@ -159,7 +159,7 @@ class PackageController extends AbstractActionController {
             if ($ret == 'Yes') {
                 $id = (int) $request->getPost('id');
                 
-                $package = $em->getRepository("ErsBase\Entity\Package")
+                $package = $em->getRepository('ErsBase\Entity\Package')
                     ->findOneBy(array('id' => $id));
                 
                 foreach($package->getItems() as $item) {
@@ -187,7 +187,7 @@ class PackageController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $package = $em->getRepository("ErsBase\Entity\Package")
+        $package = $em->getRepository('ErsBase\Entity\Package')
                 ->findOneBy(array('id' => $id));
         
         $forrest = new Service\BreadcrumbService();
@@ -202,7 +202,7 @@ class PackageController extends AbstractActionController {
             if ($ret == 'Yes') {
                 $id = (int) $request->getPost('id');
                 
-                $package = $em->getRepository("ErsBase\Entity\Package")
+                $package = $em->getRepository('ErsBase\Entity\Package')
                     ->findOneBy(array('id' => $id));
                 
                 foreach($package->getItems() as $item) {
@@ -230,7 +230,7 @@ class PackageController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $package = $em->getRepository("ErsBase\Entity\Package")
+        $package = $em->getRepository('ErsBase\Entity\Package')
                 ->findOneBy(array('id' => $id));
         
         $forrest = new Service\BreadcrumbService();
@@ -258,7 +258,7 @@ class PackageController extends AbstractActionController {
         $deadlineService = $this->getServiceLocator()
                 ->get('ErsBase\Service\DeadlineService:price');
         /*$deadlineService = new \ErsBase\Service\DeadlineService();
-        $deadlines = $em->getRepository("ErsBase\Entity\Deadline")
+        $deadlines = $em->getRepository('ErsBase\Entity\Deadline')
                     ->findBy(array('price_change' => '1'));
         $deadlineService->setDeadlines($deadlines);*/
 
@@ -273,7 +273,7 @@ class PackageController extends AbstractActionController {
 
             if ($ret == 'Yes') {
                 $id = (int) $request->getPost('id');
-                $package = $em->getRepository("ErsBase\Entity\Package")
+                $package = $em->getRepository('ErsBase\Entity\Package')
                     ->findOneBy(array('id' => $id));
                 
                 $itemArray = $this->recalcPackage($package, $agegroup, $deadline);
@@ -348,7 +348,7 @@ class PackageController extends AbstractActionController {
                 $codecheck = 1;
                 while($codecheck != null) {
                     $code->genCode();
-                    $codecheck = $em->getRepository("ErsBase\Entity\Code")
+                    $codecheck = $em->getRepository('ErsBase\Entity\Code')
                         ->findOneBy(array('value' => $code->getValue()));
                 }
                 $newItem->setCodeId(null);
@@ -378,7 +378,7 @@ class PackageController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $package = $em->getRepository("ErsBase\Entity\Package")
+        $package = $em->getRepository('ErsBase\Entity\Package')
                 ->findOneBy(array('id' => $id));
         
         /*$languages = array(
@@ -421,7 +421,7 @@ class PackageController extends AbstractActionController {
             if ($form->isValid()) {
                 $id = (int) $request->getPost('id');
                 
-                $package = $em->getRepository("ErsBase\Entity\Package")
+                $package = $em->getRepository('ErsBase\Entity\Package')
                     ->findOneBy(array('id' => $id));
                 
                 $eticketService = $this->getServiceLocator()
@@ -474,7 +474,7 @@ class PackageController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $package = $em->getRepository("ErsBase\Entity\Package")
+        $package = $em->getRepository('ErsBase\Entity\Package')
                 ->findOneBy(array('id' => $id));
         
         $request = $this->getRequest();
@@ -484,7 +484,7 @@ class PackageController extends AbstractActionController {
             if ($ret == 'Yes') {
                 $id = (int) $request->getPost('id');
                 
-                $package = $em->getRepository("ErsBase\Entity\Package")
+                $package = $em->getRepository('ErsBase\Entity\Package')
                     ->findOneBy(array('id' => $id));
                 
                 if($package->getStatus() != 'paid') {
@@ -571,7 +571,7 @@ class PackageController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $package = $em->getRepository("ErsBase\Entity\Package")
+        $package = $em->getRepository('ErsBase\Entity\Package')
                 ->findOneBy(array('id' => $id));
         
         $form = new Form\SearchPackage();
@@ -682,10 +682,10 @@ class PackageController extends AbstractActionController {
 
             if ($form->isValid()) {
                 $data = $form->getData();
-                $user = $em->getRepository("ErsBase\Entity\User")
+                $user = $em->getRepository('ErsBase\Entity\User')
                     ->findOneBy(array('id' => $data['user_id']));
                 
-                $package = $em->getRepository("ErsBase\Entity\Package")
+                $package = $em->getRepository('ErsBase\Entity\Package')
                     ->findOneBy(array('id' => $data['package_id']));
                 
                 $log = new Entity\Log();
@@ -723,13 +723,13 @@ class PackageController extends AbstractActionController {
         
         $user = null;
         if($user_id != 0) {
-            $user = $em->getRepository("ErsBase\Entity\User")
+            $user = $em->getRepository('ErsBase\Entity\User')
                     ->findOneBy(array('id' => $user_id));
         }
         
         $package = null;
         if($package_id != 0) {
-            $package = $em->getRepository("ErsBase\Entity\Package")
+            $package = $em->getRepository('ErsBase\Entity\Package')
                     ->findOneBy(array('id' => $package_id));
         }
         
@@ -760,7 +760,7 @@ class PackageController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $package = $em->getRepository("ErsBase\Entity\Package")
+        $package = $em->getRepository('ErsBase\Entity\Package')
                 ->findOneBy(array('id' => $id));
         
         $form = new Form\SearchOrder();
@@ -860,7 +860,7 @@ class PackageController extends AbstractActionController {
             if ($form->isValid()) {
                 $data = $form->getData();
                 
-                $package = $em->getRepository("ErsBase\Entity\Package")
+                $package = $em->getRepository('ErsBase\Entity\Package')
                     ->findOneBy(array('id' => $data['package_id']));
                 
                 if($data['order_id'] == '') {
@@ -871,7 +871,7 @@ class PackageController extends AbstractActionController {
                     $codecheck = 1;
                     while($codecheck != null) {
                         $code->genCode();
-                        $codecheck = $em->getRepository("ErsBase\Entity\Code")
+                        $codecheck = $em->getRepository('ErsBase\Entity\Code')
                             ->findOneBy(array('value' => $code->getValue()));
                     }
                     $order->setCode($code);
@@ -879,7 +879,7 @@ class PackageController extends AbstractActionController {
                     $buyer = $package->getParticipant();
                     $order->setBuyer($buyer);
                 } else {
-                    $order = $em->getRepository("ErsBase\Entity\Order")
+                    $order = $em->getRepository('ErsBase\Entity\Order')
                         ->findOneBy(array('id' => $data['order_id']));
                     
                     
@@ -938,14 +938,14 @@ class PackageController extends AbstractActionController {
         
         $order = null;
         if($order_id != 0) {
-            $order = $em->getRepository("ErsBase\Entity\Order")
+            $order = $em->getRepository('ErsBase\Entity\Order')
                     ->findOneBy(array('id' => $order_id));
             $form->get('order_id')->setValue($order->getId());
         }
         
         $package = null;
         if($package_id != 0) {
-            $package = $em->getRepository("ErsBase\Entity\Package")
+            $package = $em->getRepository('ErsBase\Entity\Package')
                     ->findOneBy(array('id' => $package_id));
             $form->get('package_id')->setValue($package->getId());
         }

--- a/module/Admin/src/Admin/Controller/PaymentTypeController.php
+++ b/module/Admin/src/Admin/Controller/PaymentTypeController.php
@@ -22,7 +22,7 @@ class PaymentTypeController extends AbstractActionController {
             ->get('Doctrine\ORM\EntityManager');
         
         return new ViewModel(array(
-            'paymenttypes' => $em->getRepository("ErsBase\Entity\PaymentType")
+            'paymenttypes' => $em->getRepository('ErsBase\Entity\PaymentType')
                 ->findBy(array(), array('position' => 'ASC')),
         ));
     }
@@ -44,7 +44,7 @@ class PaymentTypeController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $deadlines = $em->getRepository("ErsBase\Entity\Deadline")
+        $deadlines = $em->getRepository('ErsBase\Entity\Deadline')
                 ->findBy(array(), array('deadline' => 'ASC'));
         $options = array();
         foreach($deadlines as $deadline) {
@@ -78,14 +78,14 @@ class PaymentTypeController extends AbstractActionController {
                 if($paymenttype->getActiveFromId() == 0) {
                     $paymenttype->setActiveFromId(null);
                 } else {
-                    $activeFrom = $em->getRepository("ErsBase\Entity\Deadline")
+                    $activeFrom = $em->getRepository('ErsBase\Entity\Deadline')
                         ->findOneBy(array('id' => $paymenttype->getActiveFromId()));
                     $paymenttype->setActiveFrom($activeFrom);
                 }
                 if($paymenttype->getActiveUntilId() == 0) {
                     $paymenttype->setActiveUntilId(null);
                 } else {
-                    $activeUntil = $em->getRepository("ErsBase\Entity\Deadline")
+                    $activeUntil = $em->getRepository('ErsBase\Entity\Deadline')
                         ->findOneBy(array('id' => $paymenttype->getActiveUntilId()));
                     $paymenttype->setActiveUntil($activeUntil);
                 }
@@ -112,7 +112,7 @@ class PaymentTypeController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $deadlines = $em->getRepository("ErsBase\Entity\Deadline")
+        $deadlines = $em->getRepository('ErsBase\Entity\Deadline')
                 ->findBy(array(), array('deadline' => 'ASC'));
         $options = array();
         foreach($deadlines as $deadline) {
@@ -146,14 +146,14 @@ class PaymentTypeController extends AbstractActionController {
                 if($paymenttype->getActiveFromId() == 0) {
                     $paymenttype->setActiveFromId(null);
                 } else {
-                    $activeFrom = $em->getRepository("ErsBase\Entity\Deadline")
+                    $activeFrom = $em->getRepository('ErsBase\Entity\Deadline')
                         ->findOneBy(array('id' => $paymenttype->getActiveFromId()));
                     $paymenttype->setActiveFrom($activeFrom);
                 }
                 if($paymenttype->getActiveUntilId() == 0) {
                     $paymenttype->setActiveUntilId(null);
                 } else {
-                    $activeUntil = $em->getRepository("ErsBase\Entity\Deadline")
+                    $activeUntil = $em->getRepository('ErsBase\Entity\Deadline')
                         ->findOneBy(array('id' => $paymenttype->getActiveUntilId()));
                     $paymenttype->setActiveUntil($activeUntil);
                 }
@@ -180,7 +180,7 @@ class PaymentTypeController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $deadlines = $em->getRepository("ErsBase\Entity\Deadline")
+        $deadlines = $em->getRepository('ErsBase\Entity\Deadline')
                 ->findBy(array(), array('deadline' => 'ASC'));
         $options = array();
         foreach($deadlines as $deadline) {
@@ -214,14 +214,14 @@ class PaymentTypeController extends AbstractActionController {
                 if($paymenttype->getActiveFromId() == 0) {
                     $paymenttype->setActiveFromId(null);
                 } else {
-                    $activeFrom = $em->getRepository("ErsBase\Entity\Deadline")
+                    $activeFrom = $em->getRepository('ErsBase\Entity\Deadline')
                         ->findOneBy(array('id' => $paymenttype->getActiveFromId()));
                     $paymenttype->setActiveFrom($activeFrom);
                 }
                 if($paymenttype->getActiveUntilId() == 0) {
                     $paymenttype->setActiveUntilId(null);
                 } else {
-                    $activeUntil = $em->getRepository("ErsBase\Entity\Deadline")
+                    $activeUntil = $em->getRepository('ErsBase\Entity\Deadline')
                         ->findOneBy(array('id' => $paymenttype->getActiveUntilId()));
                     $paymenttype->setActiveUntil($activeUntil);
                 }
@@ -248,7 +248,7 @@ class PaymentTypeController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $deadlines = $em->getRepository("ErsBase\Entity\Deadline")
+        $deadlines = $em->getRepository('ErsBase\Entity\Deadline')
                 ->findBy(array(), array('deadline' => 'ASC'));
         $options = array();
         foreach($deadlines as $deadline) {
@@ -282,14 +282,14 @@ class PaymentTypeController extends AbstractActionController {
                 if($paymenttype->getActiveFromId() == 0) {
                     $paymenttype->setActiveFromId(null);
                 } else {
-                    $activeFrom = $em->getRepository("ErsBase\Entity\Deadline")
+                    $activeFrom = $em->getRepository('ErsBase\Entity\Deadline')
                         ->findOneBy(array('id' => $paymenttype->getActiveFromId()));
                     $paymenttype->setActiveFrom($activeFrom);
                 }
                 if($paymenttype->getActiveUntilId() == 0) {
                     $paymenttype->setActiveUntilId(null);
                 } else {
-                    $activeUntil = $em->getRepository("ErsBase\Entity\Deadline")
+                    $activeUntil = $em->getRepository('ErsBase\Entity\Deadline')
                         ->findOneBy(array('id' => $paymenttype->getActiveUntilId()));
                     $paymenttype->setActiveUntil($activeUntil);
                 }
@@ -353,9 +353,9 @@ class PaymentTypeController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $paymenttype = $em->getRepository("ErsBase\Entity\PaymentType")->findOneBy(array('id' => $id));
+        $paymenttype = $em->getRepository('ErsBase\Entity\PaymentType')->findOneBy(array('id' => $id));
             
-        $deadlines = $em->getRepository("ErsBase\Entity\Deadline")
+        $deadlines = $em->getRepository('ErsBase\Entity\Deadline')
                 ->findBy(array(), array('deadline' => 'ASC'));
         $from_options = array();
         $until_options = array();
@@ -419,13 +419,13 @@ class PaymentTypeController extends AbstractActionController {
                 if($paymenttype->getActiveFromId() == 0) {
                     $paymenttype->setActiveFromId(null);
                 } else {
-                    $activeFrom = $em->getRepository("ErsBase\Entity\Deadline")->findOneBy(array('id' => $paymenttype->getActiveFromId()));
+                    $activeFrom = $em->getRepository('ErsBase\Entity\Deadline')->findOneBy(array('id' => $paymenttype->getActiveFromId()));
                     $paymenttype->setActiveFrom($activeFrom);
                 }
                 if($paymenttype->getActiveUntilId() == 0) {
                     $paymenttype->setActiveUntilId(null);
                 } else {
-                    $activeUntil = $em->getRepository("ErsBase\Entity\Deadline")->findOneBy(array('id' => $paymenttype->getActiveUntilId()));
+                    $activeUntil = $em->getRepository('ErsBase\Entity\Deadline')->findOneBy(array('id' => $paymenttype->getActiveUntilId()));
                     $paymenttype->setActiveUntil($activeUntil);
                 }
                 
@@ -456,9 +456,9 @@ class PaymentTypeController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $paymenttype = $em->getRepository("ErsBase\Entity\PaymentType")->findOneBy(array('id' => $id));
+        $paymenttype = $em->getRepository('ErsBase\Entity\PaymentType')->findOneBy(array('id' => $id));
             
-        $deadlines = $em->getRepository("ErsBase\Entity\Deadline")
+        $deadlines = $em->getRepository('ErsBase\Entity\Deadline')
                 ->findBy(array(), array('deadline' => 'ASC'));
         $from_options = array();
         $until_options = array();
@@ -522,13 +522,13 @@ class PaymentTypeController extends AbstractActionController {
                 if($paymenttype->getActiveFromId() == 0) {
                     $paymenttype->setActiveFromId(null);
                 } else {
-                    $activeFrom = $em->getRepository("ErsBase\Entity\Deadline")->findOneBy(array('id' => $paymenttype->getActiveFromId()));
+                    $activeFrom = $em->getRepository('ErsBase\Entity\Deadline')->findOneBy(array('id' => $paymenttype->getActiveFromId()));
                     $paymenttype->setActiveFrom($activeFrom);
                 }
                 if($paymenttype->getActiveUntilId() == 0) {
                     $paymenttype->setActiveUntilId(null);
                 } else {
-                    $activeUntil = $em->getRepository("ErsBase\Entity\Deadline")->findOneBy(array('id' => $paymenttype->getActiveUntilId()));
+                    $activeUntil = $em->getRepository('ErsBase\Entity\Deadline')->findOneBy(array('id' => $paymenttype->getActiveUntilId()));
                     $paymenttype->setActiveUntil($activeUntil);
                 }
                 
@@ -559,9 +559,9 @@ class PaymentTypeController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $paymenttype = $em->getRepository("ErsBase\Entity\PaymentType")->findOneBy(array('id' => $id));
+        $paymenttype = $em->getRepository('ErsBase\Entity\PaymentType')->findOneBy(array('id' => $id));
             
-        $deadlines = $em->getRepository("ErsBase\Entity\Deadline")
+        $deadlines = $em->getRepository('ErsBase\Entity\Deadline')
                 ->findBy(array(), array('deadline' => 'ASC'));
         $from_options = array();
         $until_options = array();
@@ -625,13 +625,13 @@ class PaymentTypeController extends AbstractActionController {
                 if($paymenttype->getActiveFromId() == 0) {
                     $paymenttype->setActiveFromId(null);
                 } else {
-                    $activeFrom = $em->getRepository("ErsBase\Entity\Deadline")->findOneBy(array('id' => $paymenttype->getActiveFromId()));
+                    $activeFrom = $em->getRepository('ErsBase\Entity\Deadline')->findOneBy(array('id' => $paymenttype->getActiveFromId()));
                     $paymenttype->setActiveFrom($activeFrom);
                 }
                 if($paymenttype->getActiveUntilId() == 0) {
                     $paymenttype->setActiveUntilId(null);
                 } else {
-                    $activeUntil = $em->getRepository("ErsBase\Entity\Deadline")->findOneBy(array('id' => $paymenttype->getActiveUntilId()));
+                    $activeUntil = $em->getRepository('ErsBase\Entity\Deadline')->findOneBy(array('id' => $paymenttype->getActiveUntilId()));
                     $paymenttype->setActiveUntil($activeUntil);
                 }
                 
@@ -662,9 +662,9 @@ class PaymentTypeController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $paymenttype = $em->getRepository("ErsBase\Entity\PaymentType")->findOneBy(array('id' => $id));
+        $paymenttype = $em->getRepository('ErsBase\Entity\PaymentType')->findOneBy(array('id' => $id));
             
-        $deadlines = $em->getRepository("ErsBase\Entity\Deadline")
+        $deadlines = $em->getRepository('ErsBase\Entity\Deadline')
                 ->findBy(array(), array('deadline' => 'ASC'));
         $from_options = array();
         $until_options = array();
@@ -728,13 +728,13 @@ class PaymentTypeController extends AbstractActionController {
                 if($paymenttype->getActiveFromId() == 0) {
                     $paymenttype->setActiveFromId(null);
                 } else {
-                    $activeFrom = $em->getRepository("ErsBase\Entity\Deadline")->findOneBy(array('id' => $paymenttype->getActiveFromId()));
+                    $activeFrom = $em->getRepository('ErsBase\Entity\Deadline')->findOneBy(array('id' => $paymenttype->getActiveFromId()));
                     $paymenttype->setActiveFrom($activeFrom);
                 }
                 if($paymenttype->getActiveUntilId() == 0) {
                     $paymenttype->setActiveUntilId(null);
                 } else {
-                    $activeUntil = $em->getRepository("ErsBase\Entity\Deadline")->findOneBy(array('id' => $paymenttype->getActiveUntilId()));
+                    $activeUntil = $em->getRepository('ErsBase\Entity\Deadline')->findOneBy(array('id' => $paymenttype->getActiveUntilId()));
                     $paymenttype->setActiveUntil($activeUntil);
                 }
                 
@@ -764,7 +764,7 @@ class PaymentTypeController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $paymenttype = $em->getRepository("ErsBase\Entity\PaymentType")->findOneBy(array('id' => $id));
+        $paymenttype = $em->getRepository('ErsBase\Entity\PaymentType')->findOneBy(array('id' => $id));
 
         $form = new Form\PaymentType();
         $form->bind($paymenttype);
@@ -797,9 +797,9 @@ class PaymentTypeController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $paymenttype = $em->getRepository("ErsBase\Entity\PaymentType")
+        $paymenttype = $em->getRepository('ErsBase\Entity\PaymentType')
                 ->findOneBy(array('id' => $id));
-        $orders = $em->getRepository("ErsBase\Entity\Order")
+        $orders = $em->getRepository('ErsBase\Entity\Order')
                 ->findOneBy(array('PaymentType_id' => $id));
 
         $request = $this->getRequest();
@@ -808,7 +808,7 @@ class PaymentTypeController extends AbstractActionController {
 
             if ($del == 'Yes') {
                 $id = (int) $request->getPost('id');
-                $paymenttype = $em->getRepository("ErsBase\Entity\PaymentType")
+                $paymenttype = $em->getRepository('ErsBase\Entity\PaymentType')
                     ->findOneBy(array('id' => $id));
                 $em->remove($paymenttype);
                 $em->flush();

--- a/module/Admin/src/Admin/Controller/ProductController.php
+++ b/module/Admin/src/Admin/Controller/ProductController.php
@@ -20,7 +20,7 @@ class ProductController extends AbstractActionController {
     {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $products = $em->getRepository("ErsBase\Entity\Product")->findBy(array(), array('position' => 'ASC'));
+        $products = $em->getRepository('ErsBase\Entity\Product')->findBy(array(), array('position' => 'ASC'));
         
         $forrest = new Service\BreadcrumbService();
         $forrest->set('product', 'admin/product');
@@ -52,7 +52,7 @@ class ProductController extends AbstractActionController {
                 $em = $this->getServiceLocator()
                     ->get('Doctrine\ORM\EntityManager');
                 
-                $tax = $em->getRepository("ErsBase\Entity\Tax")->findOneBy(array('id' => $product->getTaxId()));
+                $tax = $em->getRepository('ErsBase\Entity\Tax')->findOneBy(array('id' => $product->getTaxId()));
                 $product->setTax($tax);
                 
                 $em->persist($product);
@@ -80,7 +80,7 @@ class ProductController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $product = $em->getRepository("ErsBase\Entity\Product")->findOneBy(array('id' => $id));
+        $product = $em->getRepository('ErsBase\Entity\Product')->findOneBy(array('id' => $id));
 
         $form = $this->getServiceLocator()
                 ->get('Admin\Form\Product');
@@ -122,7 +122,7 @@ class ProductController extends AbstractActionController {
         
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $product = $em->getRepository("ErsBase\Entity\Product")
+        $product = $em->getRepository('ErsBase\Entity\Product')
                 ->findOneBy(array('id' => $id));
         
         $forrest = new Service\BreadcrumbService();
@@ -132,9 +132,9 @@ class ProductController extends AbstractActionController {
         $forrest->set('product-variant', 'admin/product', array('action' => 'view', 'id' => $id));
         $forrest->set('product-variant-value', 'admin/product', array('action' => 'view', 'id' => $id));
         
-        $deadlines = $em->getRepository("ErsBase\Entity\Deadline")
+        $deadlines = $em->getRepository('ErsBase\Entity\Deadline')
                 ->findBy(array('price_change' => '1'), array('deadline' => 'ASC'));
-        $agegroups = $em->getRepository("ErsBase\Entity\Agegroup")
+        $agegroups = $em->getRepository('ErsBase\Entity\Agegroup')
                 ->findBy(array('price_change' => '1'), array('agegroup' => 'ASC'));
         
         return new ViewModel(array(
@@ -154,7 +154,7 @@ class ProductController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $old_product = $em->getRepository("ErsBase\Entity\Product")->findOneBy(array('id' => $id));
+        $old_product = $em->getRepository('ErsBase\Entity\Product')->findOneBy(array('id' => $id));
         
         $product = clone $old_product;
 
@@ -198,9 +198,9 @@ class ProductController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $Product = $em->getRepository("ErsBase\Entity\Product")
+        $Product = $em->getRepository('ErsBase\Entity\Product')
                 ->findOneBy(array('id' => $id));
-        $Items = $em->getRepository("ErsBase\Entity\Item")
+        $Items = $em->getRepository('ErsBase\Entity\Item')
                 ->findBy(array('Product_id' => $id));
 
         $request = $this->getRequest();
@@ -209,7 +209,7 @@ class ProductController extends AbstractActionController {
 
             if ($del == 'Yes') {
                 $id = (int) $request->getPost('id');
-                $Product = $em->getRepository("ErsBase\Entity\Product")
+                $Product = $em->getRepository('ErsBase\Entity\Product')
                     ->findOneBy(array('id' => $id));
                 
                 $this->removeProductPrices($Product);
@@ -232,7 +232,7 @@ class ProductController extends AbstractActionController {
     private function removeProductPrices(Entity\Product $Product) {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $ProductPrices = $em->getRepository("ErsBase\Entity\ProductPrice")
+        $ProductPrices = $em->getRepository('ErsBase\Entity\ProductPrice')
                 ->findBy(array('Product_id' => $Product->getId()));
         foreach($ProductPrices as $price) {
             $em->remove($price);
@@ -241,10 +241,10 @@ class ProductController extends AbstractActionController {
     private function removeProductVariants(Entity\Product $Product) {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $ProductVariants = $em->getRepository("ErsBase\Entity\ProductVariant")
+        $ProductVariants = $em->getRepository('ErsBase\Entity\ProductVariant')
                 ->findBy(array('Product_id' => $Product->getId()));
         foreach($ProductVariants as $variant) {
-            $ProductVariantValues = $em->getRepository("ErsBase\Entity\ProductVariantValue")
+            $ProductVariantValues = $em->getRepository('ErsBase\Entity\ProductVariantValue')
                     ->findBy(array('ProductVariant_id' => $variant->getId()), array('position' => 'ASC'));
             foreach($ProductVariantValues as $value) {
                 $em->remove($value);

--- a/module/Admin/src/Admin/Controller/ProductPackageController.php
+++ b/module/Admin/src/Admin/Controller/ProductPackageController.php
@@ -30,7 +30,7 @@ class ProductPackageController extends AbstractActionController {
     private function getProductOptions(Entity\Product $thisProduct = null, $productId = null) {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $products = $em->getRepository("ErsBase\Entity\Product")
+        $products = $em->getRepository('ErsBase\Entity\Product')
                 ->findBy(array(), array('position' => 'ASC'));
         $options = array();
         foreach($products as $product) {
@@ -66,7 +66,7 @@ class ProductPackageController extends AbstractActionController {
         $form = new Form\ProductPackage();
         $form->get('submit')->setValue('Add');
         
-        $thisProduct = $em->getRepository("ErsBase\Entity\Product")
+        $thisProduct = $em->getRepository('ErsBase\Entity\Product')
                 ->findOneBy(array('id' => $id));
         $form->get('SubProduct_id')->setValueOptions($this->getProductOptions($thisProduct));
         $form->get('Product_id')->setValue($id);
@@ -81,12 +81,12 @@ class ProductPackageController extends AbstractActionController {
                 $productPackage->populate($form->getData());
                 
                 if($productPackage->getSubProductId() != 0) {
-                    $subProduct = $em->getRepository("ErsBase\Entity\Product")
+                    $subProduct = $em->getRepository('ErsBase\Entity\Product')
                         ->findOneBy(array('id' => $productPackage->getSubProductId()));
                     $productPackage->setSubProduct($subProduct);
                 }
                 if($productPackage->getProductId() != 0) {
-                    $product = $em->getRepository("ErsBase\Entity\Product")
+                    $product = $em->getRepository('ErsBase\Entity\Product')
                         ->findOneBy(array('id' => $productPackage->getProductId()));
                     $productPackage->setProduct($product);
                 }
@@ -127,14 +127,14 @@ class ProductPackageController extends AbstractActionController {
         
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $productPackage = $em->getRepository("ErsBase\Entity\ProductPackage")
+        $productPackage = $em->getRepository('ErsBase\Entity\ProductPackage')
                 ->findOneBy(array('id' => $id));
 
         $form = new Form\ProductPackage();
         $form->bind($productPackage);
         $form->get('submit')->setAttribute('value', 'Edit');
 
-        $thisProduct = $em->getRepository("ErsBase\Entity\Product")
+        $thisProduct = $em->getRepository('ErsBase\Entity\Product')
                 ->findOneBy(array('id' => $productPackage->getProductId()));
         $form->get('SubProduct_id')->setValueOptions($this->getProductOptions($thisProduct, $subproduct_id));
         $form->get('Product_id')->setValue($id);
@@ -147,12 +147,12 @@ class ProductPackageController extends AbstractActionController {
             if ($form->isValid()) {
                 $productPackage = $form->getData();
                 if($productPackage->getSubProductId() != 0) {
-                    $subProduct = $em->getRepository("ErsBase\Entity\Product")
+                    $subProduct = $em->getRepository('ErsBase\Entity\Product')
                         ->findOneBy(array('id' => $productPackage->getSubProductId()));
                     $productPackage->setSubProduct($subProduct);
                 }
                 if($productPackage->getProductId() != 0) {
-                    $product = $em->getRepository("ErsBase\Entity\Product")
+                    $product = $em->getRepository('ErsBase\Entity\Product')
                         ->findOneBy(array('id' => $productPackage->getProductId()));
                     $productPackage->setProduct($product);
                 }
@@ -182,11 +182,11 @@ class ProductPackageController extends AbstractActionController {
         
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $productPackage = $em->getRepository("ErsBase\Entity\ProductPackage")
+        $productPackage = $em->getRepository('ErsBase\Entity\ProductPackage')
                 ->findOneBy(array('id' => $id));
-        $product = $em->getRepository("ErsBase\Entity\Product")
+        $product = $em->getRepository('ErsBase\Entity\Product')
                 ->findOneBy(array('id' => $productPackage->getProductId()));
-        $subproduct = $em->getRepository("ErsBase\Entity\Product")
+        $subproduct = $em->getRepository('ErsBase\Entity\Product')
                 ->findOneBy(array('id' => $productPackage->getSubProductId()));
 
         $request = $this->getRequest();
@@ -195,7 +195,7 @@ class ProductPackageController extends AbstractActionController {
 
             if ($del == 'Yes') {
                 $id = (int) $request->getPost('id');
-                $productPackage = $em->getRepository("ErsBase\Entity\ProductPackage")
+                $productPackage = $em->getRepository('ErsBase\Entity\ProductPackage')
                     ->findOneBy(array('id' => $id));
                 $em->remove($productPackage);
                 $em->flush();

--- a/module/Admin/src/Admin/Controller/ProductPriceController.php
+++ b/module/Admin/src/Admin/Controller/ProductPriceController.php
@@ -33,11 +33,11 @@ class ProductPriceController extends AbstractActionController {
         
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $product = $em->getRepository("ErsBase\Entity\Product")
+        $product = $em->getRepository('ErsBase\Entity\Product')
                 ->findOneBy(array('id' => $id));
-        $deadlines = $em->getRepository("ErsBase\Entity\Deadline")
+        $deadlines = $em->getRepository('ErsBase\Entity\Deadline')
                 ->findBy(array('price_change' => '1'), array('deadline' => 'ASC'));
-        $agegroups = $em->getRepository("ErsBase\Entity\Agegroup")
+        $agegroups = $em->getRepository('ErsBase\Entity\Agegroup')
                 ->findBy(array('price_change' => '1'), array('agegroup' => 'DESC'));
         
         return new ViewModel(array(
@@ -56,7 +56,7 @@ class ProductPriceController extends AbstractActionController {
     private function getDeadlineOptions($deadlineId = null) {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $deadlines = $em->getRepository("ErsBase\Entity\Deadline")
+        $deadlines = $em->getRepository('ErsBase\Entity\Deadline')
                 ->findBy(array('price_change' => '1'), array('deadline' => 'ASC'));
         $options = array();
         foreach($deadlines as $deadline) {
@@ -91,7 +91,7 @@ class ProductPriceController extends AbstractActionController {
     private function getAgegroupOptions($agegroupId = null) {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $agegroups = $em->getRepository("ErsBase\Entity\Agegroup")
+        $agegroups = $em->getRepository('ErsBase\Entity\Agegroup')
                 ->findBy(array('price_change' => '1'), array('agegroup' => 'ASC'));
         $options = array();
         foreach($agegroups as $agegroup) {
@@ -153,7 +153,7 @@ class ProductPriceController extends AbstractActionController {
                 if($productprice->getDeadlineId() == 0) {
                     $productprice->setDeadline(null);
                 } else {
-                    $deadline = $em->getRepository("ErsBase\Entity\Deadline")
+                    $deadline = $em->getRepository('ErsBase\Entity\Deadline')
                         ->findOneBy(array('id' => $productprice->getDeadlineId()));
                     $productprice->setDeadline($deadline);
                 }
@@ -161,12 +161,12 @@ class ProductPriceController extends AbstractActionController {
                 if($productprice->getAgegroupId() == 0) {
                     $productprice->setAgegroup(null);
                 } else {
-                    $agegroup = $em->getRepository("ErsBase\Entity\Agegroup")
+                    $agegroup = $em->getRepository('ErsBase\Entity\Agegroup')
                         ->findOneBy(array('id' => $productprice->getAgegroupId()));
                     $productprice->setAgegroup($agegroup);
                 }
                 
-                $product = $em->getRepository("ErsBase\Entity\Product")
+                $product = $em->getRepository('ErsBase\Entity\Product')
                     ->findOneBy(array('id' => $productprice->getProductId()));
                 $productprice->setProduct($product);
                 
@@ -186,7 +186,7 @@ class ProductPriceController extends AbstractActionController {
             }
         }
         
-        $product = $em->getRepository("ErsBase\Entity\Product")->findOneBy(array('id' => $id));
+        $product = $em->getRepository('ErsBase\Entity\Product')->findOneBy(array('id' => $id));
         
         if(!$forrest->exists('product-price')) {
             $forrest->set('product-price', 'admin/product');
@@ -211,7 +211,7 @@ class ProductPriceController extends AbstractActionController {
         
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $productprice = $em->getRepository("ErsBase\Entity\ProductPrice")
+        $productprice = $em->getRepository('ErsBase\Entity\ProductPrice')
                 ->findOneBy(array('id' => $id));
 
         $form = new Form\ProductPrice();
@@ -245,7 +245,7 @@ class ProductPriceController extends AbstractActionController {
             }
         }
         
-        $product = $em->getRepository("ErsBase\Entity\Product")->findOneBy(array('id' => $productprice->getProductId()));
+        $product = $em->getRepository('ErsBase\Entity\Product')->findOneBy(array('id' => $productprice->getProductId()));
         
         return new ViewModel(array(
             'id' => $id,
@@ -273,7 +273,7 @@ class ProductPriceController extends AbstractActionController {
             if ($del == 'Yes') {
                 
                 $id = (int) $request->getPost('id');
-                $productprice = $em->getRepository("ErsBase\Entity\ProductPrice")
+                $productprice = $em->getRepository('ErsBase\Entity\ProductPrice')
                         ->findOneBy(array('id' => $id));
                 $em->remove($productprice);
                 $em->flush();
@@ -283,10 +283,10 @@ class ProductPriceController extends AbstractActionController {
             return $this->redirect()->toRoute($breadcrumb->route, $breadcrumb->params, $breadcrumb->options);
         }
 
-        $productprice = $em->getRepository("ErsBase\Entity\ProductPrice")
+        $productprice = $em->getRepository('ErsBase\Entity\ProductPrice')
                         ->findOneBy(array('id' => $id));
         
-        $product = $em->getRepository("ErsBase\Entity\Product")->findOneBy(array('id' => $productprice->getProductId()));
+        $product = $em->getRepository('ErsBase\Entity\Product')->findOneBy(array('id' => $productprice->getProductId()));
         
         return new ViewModel(array(
             'id'    => $id,

--- a/module/Admin/src/Admin/Controller/ProductVariantController.php
+++ b/module/Admin/src/Admin/Controller/ProductVariantController.php
@@ -53,7 +53,7 @@ class ProductVariantController extends AbstractActionController
                     ->get('Doctrine\ORM\EntityManager');
 
                 $productvariant->populate($form->getData());
-                $product = $em->getRepository("ErsBase\Entity\Product")->findOneBy(array('id' => $productvariant->getProductId()));
+                $product = $em->getRepository('ErsBase\Entity\Product')->findOneBy(array('id' => $productvariant->getProductId()));
                 $productvariant->setProduct($product);
                 
                 $em->persist($productvariant);
@@ -73,7 +73,7 @@ class ProductVariantController extends AbstractActionController
         
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $product = $em->getRepository("ErsBase\Entity\Product")->findOneBy(array('id' => $product_id));
+        $product = $em->getRepository('ErsBase\Entity\Product')->findOneBy(array('id' => $product_id));
         
         
         $breadcrumb = $forrest->get('product-variant');
@@ -97,7 +97,7 @@ class ProductVariantController extends AbstractActionController
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $productvariant = $em->getRepository("ErsBase\Entity\ProductVariant")->findOneBy(array('id' => $id));
+        $productvariant = $em->getRepository('ErsBase\Entity\ProductVariant')->findOneBy(array('id' => $id));
 
         #$form  = new Form\ProductVariant();
         $form = $this->getServiceLocator()->get('Admin\Form\ProductVariant');
@@ -124,7 +124,7 @@ class ProductVariantController extends AbstractActionController
             }
         }
         
-        $product = $em->getRepository("ErsBase\Entity\Product")->findOneBy(array('id' => $productvariant->getProductId()));
+        $product = $em->getRepository('ErsBase\Entity\Product')->findOneBy(array('id' => $productvariant->getProductId()));
 
         return new ViewModel(array(
             'id' => $id,
@@ -152,9 +152,9 @@ class ProductVariantController extends AbstractActionController
             if ($del == 'Yes') {
                 
                 $id = (int) $request->getPost('id');
-                $productvariant = $em->getRepository("ErsBase\Entity\ProductVariant")
+                $productvariant = $em->getRepository('ErsBase\Entity\ProductVariant')
                         ->findOneBy(array('id' => $id));
-                $values = $em->getRepository("ErsBase\Entity\ProductVariantValue")
+                $values = $em->getRepository('ErsBase\Entity\ProductVariantValue')
                         ->findBy(array('ProductVariant_id' => $productvariant->getId()));
                 foreach($values as $value) {
                     $em->remove($value);
@@ -167,9 +167,9 @@ class ProductVariantController extends AbstractActionController
             return $this->redirect()->toRoute($breadcrumb->route, $breadcrumb->params, $breadcrumb->options);
         }
         
-        $productvariant = $em->getRepository("ErsBase\Entity\ProductVariant")
+        $productvariant = $em->getRepository('ErsBase\Entity\ProductVariant')
                         ->findOneBy(array('id' => $id));
-        $product = $em->getRepository("ErsBase\Entity\Product")
+        $product = $em->getRepository('ErsBase\Entity\Product')
                 ->findOneBy(array('id' => $productvariant->getProductId()));
         
         return new ViewModel(array(

--- a/module/Admin/src/Admin/Controller/ProductVariantValueController.php
+++ b/module/Admin/src/Admin/Controller/ProductVariantValueController.php
@@ -32,7 +32,7 @@ class ProductVariantValueController extends AbstractActionController
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         return new ViewModel(array(
-            'productvariant' => $em->getRepository("ErsBase\Entity\ProductVariantValue")->findOneBy(array('id' => $id)),
+            'productvariant' => $em->getRepository('ErsBase\Entity\ProductVariantValue')->findOneBy(array('id' => $id)),
         ));
     }
     
@@ -63,7 +63,7 @@ class ProductVariantValueController extends AbstractActionController
                     ->get('Doctrine\ORM\EntityManager');
 
                 $value->populate($form->getData());
-                $productvariant = $em->getRepository("ErsBase\Entity\ProductVariant")->findOneBy(array('id' => $value->getProductVariantId()));
+                $productvariant = $em->getRepository('ErsBase\Entity\ProductVariant')->findOneBy(array('id' => $value->getProductVariantId()));
                 $value->setProductVariant($productvariant);
                 
                 $em->persist($value);
@@ -100,7 +100,7 @@ class ProductVariantValueController extends AbstractActionController
             $forrest->set('product-variant-value', 'admin/product');
         }
         
-        $value = $em->getRepository("ErsBase\Entity\ProductVariantValue")->findOneBy(array('id' => $id));
+        $value = $em->getRepository('ErsBase\Entity\ProductVariantValue')->findOneBy(array('id' => $id));
 
         $form  = new Form\ProductVariantValue();
         $form->bind($value);
@@ -146,7 +146,7 @@ class ProductVariantValueController extends AbstractActionController
             if ($del == 'Yes') {
                 
                 $id = (int) $request->getPost('id');
-                $value = $em->getRepository("ErsBase\Entity\ProductVariantValue")
+                $value = $em->getRepository('ErsBase\Entity\ProductVariantValue')
                         ->findOneBy(array('id' => $id));
                 $em->remove($value);
                 $em->flush();
@@ -159,7 +159,7 @@ class ProductVariantValueController extends AbstractActionController
         
         return new ViewModel(array(
             'id'    => $id,
-            'value' => $em->getRepository("ErsBase\Entity\ProductVariantValue")
+            'value' => $em->getRepository('ErsBase\Entity\ProductVariantValue')
                         ->findOneBy(array('id' => $id)),
         ));
     }

--- a/module/Admin/src/Admin/Controller/RefundController.php
+++ b/module/Admin/src/Admin/Controller/RefundController.php
@@ -21,9 +21,9 @@ class RefundController extends AbstractActionController {
         /*
          * search for orders that do contain items in status refund
          */
-        /*$qb = $em->getRepository("ErsBase\Entity\Order")
+        /*$qb = $em->getRepository('ErsBase\Entity\Order')
                 ->createQueryBuild('o');*/
-        $qb = $em->getRepository("ErsBase\Entity\Order")
+        $qb = $em->getRepository('ErsBase\Entity\Order')
                 ->createQueryBuilder('o');
         $qb->join('o.packages', 'p');
         $qb->join('p.items', 'i');
@@ -31,7 +31,7 @@ class RefundController extends AbstractActionController {
         
         $orders = $qb->getQuery()->getResult();
         
-        $items = $em->getRepository("ErsBase\Entity\Item")
+        $items = $em->getRepository('ErsBase\Entity\Item')
                 ->findBy(array('status' => 'refund'), array('updated' => 'DESC'));
         
         return new ViewModel(array(
@@ -47,7 +47,7 @@ class RefundController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $order = $em->getRepository("ErsBase\Entity\Order")
+        $order = $em->getRepository('ErsBase\Entity\Order')
                 ->findOneBy(array('id' => $id));
 
         #$form = $this->getServiceLocator()->get('Admin\Form\Product');
@@ -63,7 +63,7 @@ class RefundController extends AbstractActionController {
             
             if ($form->isValid()) {
                 $data = $form->getData();
-                $order = $em->getRepository("ErsBase\Entity\Order")
+                $order = $em->getRepository('ErsBase\Entity\Order')
                     ->findOneBy(array('id' => $data['id']));
                 $order->setRefundSum($order->getRefundSum()+$data['amount']);
                 $em->persist($order);

--- a/module/Admin/src/Admin/Controller/RoleController.php
+++ b/module/Admin/src/Admin/Controller/RoleController.php
@@ -22,7 +22,7 @@ class RoleController extends AbstractActionController {
             ->get('Doctrine\ORM\EntityManager');
         
         return new ViewModel(array(
-            'roles' => $em->getRepository("ErsBase\Entity\Role")->findBy(array(),array('roleId' => 'ASC')),
+            'roles' => $em->getRepository('ErsBase\Entity\Role')->findBy(array(),array('roleId' => 'ASC')),
          ));
     }
 
@@ -52,7 +52,7 @@ class RoleController extends AbstractActionController {
                     ->get('Doctrine\ORM\EntityManager');
                 
                 if(is_numeric($role->getParentId()) && $role->getParentId() > 0) {
-                    $parent = $em->getRepository("ErsBase\Entity\Role")
+                    $parent = $em->getRepository('ErsBase\Entity\Role')
                         ->findOneBy(array('id' => $role->getParentId()));
                 
                     $role->setParent($parent);
@@ -92,7 +92,7 @@ class RoleController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $role = $em->getRepository("ErsBase\Entity\Role")->findOneBy(array('id' => $id));
+        $role = $em->getRepository('ErsBase\Entity\Role')->findOneBy(array('id' => $id));
 
         #$form = new Form\Role();
         $form = $this->getServiceLocator()->get('Admin\Form\Role');
@@ -136,7 +136,7 @@ class RoleController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $role = $em->getRepository("ErsBase\Entity\Role")
+        $role = $em->getRepository('ErsBase\Entity\Role')
                 ->findOneBy(array('id' => $id));
 
         $request = $this->getRequest();
@@ -145,7 +145,7 @@ class RoleController extends AbstractActionController {
 
             if ($del == 'Yes') {
                 $id = (int) $request->getPost('id');
-                $role = $em->getRepository("ErsBase\Entity\Role")
+                $role = $em->getRepository('ErsBase\Entity\Role')
                     ->findOneBy(array('id' => $id));
                 $em->remove($role);
                 $em->flush();
@@ -154,7 +154,7 @@ class RoleController extends AbstractActionController {
             return $this->redirect()->toRoute($breadcrumb->route, $breadcrumb->params, $breadcrumb->options);
         }
         
-        $childs = $em->getRepository("ErsBase\Entity\Role")
+        $childs = $em->getRepository('ErsBase\Entity\Role')
                 ->findBy(array('Parent_id' => $id));
         
         return new ViewModel(array(

--- a/module/Admin/src/Admin/Controller/StatisticController.php
+++ b/module/Admin/src/Admin/Controller/StatisticController.php
@@ -184,7 +184,7 @@ class StatisticController extends AbstractActionController {
         /*
          * === by product variant ===
          */
-        $variants = $em->getRepository("ErsBase\Entity\ProductVariant")
+        $variants = $em->getRepository('ErsBase\Entity\ProductVariant')
                 ->findBy(array('type' => 'select'));
         
         $variantStats = array();
@@ -229,7 +229,7 @@ class StatisticController extends AbstractActionController {
         $activeStats = array();
         $matchingStats = array();
         
-        $bankaccounts = $em->getRepository("ErsBase\Entity\BankAccount")
+        $bankaccounts = $em->getRepository('ErsBase\Entity\BankAccount')
                 ->findAll();
         
         /* @var $bankaccount \ErsBase\Entity\BankAccount */
@@ -267,7 +267,7 @@ class StatisticController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $qb = $em->getRepository("ErsBase\Entity\Item")->createQueryBuilder('i');
+        $qb = $em->getRepository('ErsBase\Entity\Item')->createQueryBuilder('i');
         $qb->where("i.shipped = 1");
         $qb->andWhere($qb->expr()->orX(
                 $qb->expr()->eq("i.Product_id", "1"),

--- a/module/Admin/src/Admin/Controller/StatusController.php
+++ b/module/Admin/src/Admin/Controller/StatusController.php
@@ -20,7 +20,7 @@ class StatusController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         return new ViewModel(array(
-            'status' => $em->getRepository("ErsBase\Entity\Status")->findBy(array(), array('position' => 'ASC')),
+            'status' => $em->getRepository('ErsBase\Entity\Status')->findBy(array(), array('position' => 'ASC')),
         ));
     }
 
@@ -71,7 +71,7 @@ class StatusController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $status = $em->getRepository("ErsBase\Entity\Status")->findOneBy(array('id' => $id));
+        $status = $em->getRepository('ErsBase\Entity\Status')->findOneBy(array('id' => $id));
 
         $form  = new Form\Status();
         $form->bind($status);
@@ -117,7 +117,7 @@ class StatusController extends AbstractActionController {
             if ($del == 'Yes') {
                 
                 $id = (int) $request->getPost('id');
-                $status = $em->getRepository("ErsBase\Entity\Status")
+                $status = $em->getRepository('ErsBase\Entity\Status')
                         ->findOneBy(array('id' => $id));
                 $em->remove($status);
                 $em->flush();
@@ -128,7 +128,7 @@ class StatusController extends AbstractActionController {
 
         return new ViewModel(array(
             'id'    => $id,
-            'status' => $status = $em->getRepository("ErsBase\Entity\Status")
+            'status' => $status = $em->getRepository('ErsBase\Entity\Status')
                 ->findOneBy(array('id' => $id)),
             'breadcrumb' => $breadcrumb,
         ));

--- a/module/Admin/src/Admin/Controller/TaxController.php
+++ b/module/Admin/src/Admin/Controller/TaxController.php
@@ -20,7 +20,7 @@ class TaxController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         return new ViewModel(array(
-            'taxes' => $em->getRepository("ErsBase\Entity\Tax")->findBy(array(), array('percentage' => 'ASC')),
+            'taxes' => $em->getRepository('ErsBase\Entity\Tax')->findBy(array(), array('percentage' => 'ASC')),
         ));
     }
 
@@ -74,7 +74,7 @@ class TaxController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $tax = $em->getRepository("ErsBase\Entity\Tax")->findOneBy(array('id' => $id));
+        $tax = $em->getRepository('ErsBase\Entity\Tax')->findOneBy(array('id' => $id));
 
         $form  = new Form\Tax();
         $form->bind($tax);
@@ -124,7 +124,7 @@ class TaxController extends AbstractActionController {
             if ($del == 'Yes') {
                 
                 $id = (int) $request->getPost('id');
-                $tax = $em->getRepository("ErsBase\Entity\Tax")
+                $tax = $em->getRepository('ErsBase\Entity\Tax')
                         ->findOneBy(array('id' => $id));
                 $em->remove($tax);
                 $em->flush();
@@ -135,7 +135,7 @@ class TaxController extends AbstractActionController {
 
         return new ViewModel(array(
             'id'    => $id,
-            'tax' => $tax = $em->getRepository("ErsBase\Entity\Tax")
+            'tax' => $tax = $em->getRepository('ErsBase\Entity\Tax')
                 ->findOneBy(array('id' => $id)),
             'breadcrumb' => $breadcrumb,
         ));

--- a/module/Admin/src/Admin/Controller/TestController.php
+++ b/module/Admin/src/Admin/Controller/TestController.php
@@ -27,9 +27,9 @@ class TestController extends AbstractActionController {
 
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        /*$orders = $em->getRepository("ErsBase\Entity\Order")
+        /*$orders = $em->getRepository('ErsBase\Entity\Order')
                 ->findBy(array(), array('created' => 'ASC'));*/
-        $packages = $em->getRepository("ErsBase\Entity\Package")
+        $packages = $em->getRepository('ErsBase\Entity\Package')
                 ->findBy(array(), array('created' => 'ASC'));
         
         $filename = getcwd() . "/tmp/excel-" . date( "m-d-Y" ) . ".xls";
@@ -106,7 +106,7 @@ class TestController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $qb = $em->getRepository("ErsBase\Entity\Order")->createQueryBuilder('n');
+        $qb = $em->getRepository('ErsBase\Entity\Order')->createQueryBuilder('n');
         
         /*$em = $this->getEntityManager();
         $queryBuilder = $em->createQueryBuilder();
@@ -136,7 +136,7 @@ class TestController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $orders = $em->getRepository("ErsBase\Entity\Order")
+        $orders = $em->getRepository('ErsBase\Entity\Order')
                 ->findBy(array('payment_status' => 'paid'));
         
         $orderSum = 0;
@@ -156,7 +156,7 @@ class TestController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $orders = $em->getRepository("ErsBase\Entity\Order")
+        $orders = $em->getRepository('ErsBase\Entity\Order')
                 ->findBy(array('total_sum' => 0));
         $count = 0;
         foreach($orders as $order) {
@@ -175,10 +175,10 @@ class TestController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $package = $em->getRepository("ErsBase\Entity\Package")
+        $package = $em->getRepository('ErsBase\Entity\Package')
                 ->findOneBy(array('id' => 52));
         
-        $products = $em->getRepository("ErsBase\Entity\Product")
+        $products = $em->getRepository('ErsBase\Entity\Product')
                 ->findAll();
         
         $config = $this->getServiceLocator()->get('Config');

--- a/module/Admin/src/Admin/Controller/UserController.php
+++ b/module/Admin/src/Admin/Controller/UserController.php
@@ -27,7 +27,7 @@ class UserController extends AbstractActionController {
             ->get('Doctrine\ORM\EntityManager');
         
         return new ViewModel(array(
-            'users' => $em->getRepository("ErsBase\Entity\User")->findAll(),
+            'users' => $em->getRepository('ErsBase\Entity\User')->findAll(),
          ));
     }
 
@@ -35,12 +35,12 @@ class UserController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $qb1 = $em->getRepository("ErsBase\Entity\Country")->createQueryBuilder('n');
+        $qb1 = $em->getRepository('ErsBase\Entity\Country')->createQueryBuilder('n');
         $qb1->where($qb1->expr()->isNotNull('n.position'));
         $qb1->orderBy('n.position', 'ASC');
         $result1 = $qb1->getQuery()->getResult();
         
-        $qb2 = $em->getRepository("ErsBase\Entity\Country")->createQueryBuilder('n');
+        $qb2 = $em->getRepository('ErsBase\Entity\Country')->createQueryBuilder('n');
         $qb2->where($qb2->expr()->isNull('n.position'));
         $qb2->orderBy('n.name', 'ASC');
         $result2 = $qb2->getQuery()->getResult();
@@ -147,7 +147,7 @@ class UserController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $user = $em->getRepository("ErsBase\Entity\User")->findOneBy(array('id' => $id));
+        $user = $em->getRepository('ErsBase\Entity\User')->findOneBy(array('id' => $id));
         
         $form = new Form\User();
         $form->bind($user);
@@ -202,7 +202,7 @@ class UserController extends AbstractActionController {
         }
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $user = $em->getRepository("ErsBase\Entity\User")
+        $user = $em->getRepository('ErsBase\Entity\User')
                 ->findOneBy(array('id' => $id));
 
         $request = $this->getRequest();
@@ -211,7 +211,7 @@ class UserController extends AbstractActionController {
 
             if ($del == 'Yes') {
                 $id = (int) $request->getPost('id');
-                $user = $em->getRepository("ErsBase\Entity\User")
+                $user = $em->getRepository('ErsBase\Entity\User')
                     ->findOneBy(array('id' => $id));
                 $em->remove($user);
                 $em->flush();

--- a/module/Admin/src/Admin/Cron/TestCron.php
+++ b/module/Admin/src/Admin/Cron/TestCron.php
@@ -15,7 +15,7 @@ class TestCron {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $orders = $em->getRepository("ErsBase\Entity\Order")
+        $orders = $em->getRepository('ErsBase\Entity\Order')
                 ->findBy(array(), array('created' => 'DESC'));
         
         $logger = $this->getServiceLocator()->get('Logger');

--- a/module/Admin/src/Admin/InputFilter/AcceptBuyerChange.php
+++ b/module/Admin/src/Admin/InputFilter/AcceptBuyerChange.php
@@ -61,7 +61,7 @@ class AcceptBuyerChange implements InputFilterAwareInterface
                                 $em = $this->getServiceLocator()
                                     ->get('Doctrine\ORM\EntityManager');
                                 
-                                $order = $em->getRepository("ErsBase\Entity\Order")
+                                $order = $em->getRepository('ErsBase\Entity\Order')
                                     ->findOneBy(array('id' => $value));
                 
                                 if($order) {
@@ -97,7 +97,7 @@ class AcceptBuyerChange implements InputFilterAwareInterface
                                 $em = $this->getServiceLocator()
                                     ->get('Doctrine\ORM\EntityManager');
                                 
-                                $user = $em->getRepository("ErsBase\Entity\User")
+                                $user = $em->getRepository('ErsBase\Entity\User')
                                     ->findOneBy(array('id' => $value));
                 
                                 if($user) {

--- a/module/Admin/src/Admin/InputFilter/AcceptMovePackage.php
+++ b/module/Admin/src/Admin/InputFilter/AcceptMovePackage.php
@@ -60,7 +60,7 @@ class AcceptMovePackage implements InputFilterAwareInterface
                                 $em = $this->getServiceLocator()
                                     ->get('Doctrine\ORM\EntityManager');
                                 
-                                $package = $em->getRepository("ErsBase\Entity\Package")
+                                $package = $em->getRepository('ErsBase\Entity\Package')
                                     ->findOneBy(array('id' => $value));
                 
                                 if($package) {
@@ -100,7 +100,7 @@ class AcceptMovePackage implements InputFilterAwareInterface
                                 $em = $this->getServiceLocator()
                                     ->get('Doctrine\ORM\EntityManager');
                                 
-                                $order = $em->getRepository("ErsBase\Entity\Order")
+                                $order = $em->getRepository('ErsBase\Entity\Order')
                                     ->findOneBy(array('id' => $value));
                 
                                 if($order) {

--- a/module/Admin/src/Admin/InputFilter/AcceptParticipantChangeItem.php
+++ b/module/Admin/src/Admin/InputFilter/AcceptParticipantChangeItem.php
@@ -60,7 +60,7 @@ class AcceptParticipantChangeItem implements InputFilterAwareInterface
                                 $em = $this->getServiceLocator()
                                     ->get('Doctrine\ORM\EntityManager');
                                 
-                                $item = $em->getRepository("ErsBase\Entity\Item")
+                                $item = $em->getRepository('ErsBase\Entity\Item')
                                     ->findOneBy(array('id' => $value));
                 
                                 if($item) {
@@ -96,7 +96,7 @@ class AcceptParticipantChangeItem implements InputFilterAwareInterface
                                 $em = $this->getServiceLocator()
                                     ->get('Doctrine\ORM\EntityManager');
                                 
-                                $user = $em->getRepository("ErsBase\Entity\User")
+                                $user = $em->getRepository('ErsBase\Entity\User')
                                     ->findOneBy(array('id' => $value));
                 
                                 if($user) {

--- a/module/Admin/src/Admin/InputFilter/AcceptParticipantChangePackage.php
+++ b/module/Admin/src/Admin/InputFilter/AcceptParticipantChangePackage.php
@@ -60,7 +60,7 @@ class AcceptParticipantChangePackage implements InputFilterAwareInterface
                                 $em = $this->getServiceLocator()
                                     ->get('Doctrine\ORM\EntityManager');
                                 
-                                $package = $em->getRepository("ErsBase\Entity\Package")
+                                $package = $em->getRepository('ErsBase\Entity\Package')
                                     ->findOneBy(array('id' => $value));
                 
                                 if($package) {
@@ -96,7 +96,7 @@ class AcceptParticipantChangePackage implements InputFilterAwareInterface
                                 $em = $this->getServiceLocator()
                                     ->get('Doctrine\ORM\EntityManager');
                                 
-                                $user = $em->getRepository("ErsBase\Entity\User")
+                                $user = $em->getRepository('ErsBase\Entity\User')
                                     ->findOneBy(array('id' => $value));
                 
                                 if($user) {

--- a/module/Admin/src/Admin/InputFilter/PaymentTypeBankTransfer.php
+++ b/module/Admin/src/Admin/InputFilter/PaymentTypeBankTransfer.php
@@ -147,9 +147,9 @@ class PaymentTypeBankTransfer implements InputFilterAwareInterface
                                 return true;
                             }
                             
-                            $activeFrom = $em->getRepository("ErsBase\Entity\Deadline")
+                            $activeFrom = $em->getRepository('ErsBase\Entity\Deadline')
                                 ->findOneBy(array('id' => $value));
-                            $activeUntil = $em->getRepository("ErsBase\Entity\Deadline")
+                            $activeUntil = $em->getRepository('ErsBase\Entity\Deadline')
                                 ->findOneBy(array('id' => $context['activeUntil_id']));
                             
                             $diff = $activeFrom->getDeadline()->getTimestamp() - $activeUntil->getDeadline()->getTimestamp();
@@ -209,9 +209,9 @@ class PaymentTypeBankTransfer implements InputFilterAwareInterface
                                 return true;
                             }
                             
-                            $activeFrom = $em->getRepository("ErsBase\Entity\Deadline")
+                            $activeFrom = $em->getRepository('ErsBase\Entity\Deadline')
                                 ->findOneBy(array('id' => $context['activeFrom_id']));
-                            $activeUntil = $em->getRepository("ErsBase\Entity\Deadline")
+                            $activeUntil = $em->getRepository('ErsBase\Entity\Deadline')
                                 ->findOneBy(array('id' => $value));
                             
                             $diff = $activeFrom->getDeadline()->getTimestamp() - $activeUntil->getDeadline()->getTimestamp();

--- a/module/Admin/src/Admin/InputFilter/PaymentTypeCheque.php
+++ b/module/Admin/src/Admin/InputFilter/PaymentTypeCheque.php
@@ -147,9 +147,9 @@ class PaymentTypeCheque implements InputFilterAwareInterface
                                 return true;
                             }
                             
-                            $activeFrom = $em->getRepository("ErsBase\Entity\Deadline")
+                            $activeFrom = $em->getRepository('ErsBase\Entity\Deadline')
                                 ->findOneBy(array('id' => $value));
-                            $activeUntil = $em->getRepository("ErsBase\Entity\Deadline")
+                            $activeUntil = $em->getRepository('ErsBase\Entity\Deadline')
                                 ->findOneBy(array('id' => $context['activeUntil_id']));
                             
                             $diff = $activeFrom->getDeadline()->getTimestamp() - $activeUntil->getDeadline()->getTimestamp();
@@ -209,9 +209,9 @@ class PaymentTypeCheque implements InputFilterAwareInterface
                                 return true;
                             }
                             
-                            $activeFrom = $em->getRepository("ErsBase\Entity\Deadline")
+                            $activeFrom = $em->getRepository('ErsBase\Entity\Deadline')
                                 ->findOneBy(array('id' => $context['activeFrom_id']));
-                            $activeUntil = $em->getRepository("ErsBase\Entity\Deadline")
+                            $activeUntil = $em->getRepository('ErsBase\Entity\Deadline')
                                 ->findOneBy(array('id' => $value));
                             
                             $diff = $activeFrom->getDeadline()->getTimestamp() - $activeUntil->getDeadline()->getTimestamp();

--- a/module/Admin/src/Admin/InputFilter/PaymentTypePayPal.php
+++ b/module/Admin/src/Admin/InputFilter/PaymentTypePayPal.php
@@ -147,9 +147,9 @@ class PaymentTypePayPal implements InputFilterAwareInterface
                                 return true;
                             }
                             
-                            $activeFrom = $em->getRepository("ErsBase\Entity\Deadline")
+                            $activeFrom = $em->getRepository('ErsBase\Entity\Deadline')
                                 ->findOneBy(array('id' => $value));
-                            $activeUntil = $em->getRepository("ErsBase\Entity\Deadline")
+                            $activeUntil = $em->getRepository('ErsBase\Entity\Deadline')
                                 ->findOneBy(array('id' => $context['activeUntil_id']));
                             
                             $diff = $activeFrom->getDeadline()->getTimestamp() - $activeUntil->getDeadline()->getTimestamp();
@@ -209,9 +209,9 @@ class PaymentTypePayPal implements InputFilterAwareInterface
                                 return true;
                             }
                             
-                            $activeFrom = $em->getRepository("ErsBase\Entity\Deadline")
+                            $activeFrom = $em->getRepository('ErsBase\Entity\Deadline')
                                 ->findOneBy(array('id' => $context['activeFrom_id']));
-                            $activeUntil = $em->getRepository("ErsBase\Entity\Deadline")
+                            $activeUntil = $em->getRepository('ErsBase\Entity\Deadline')
                                 ->findOneBy(array('id' => $value));
                             
                             $diff = $activeFrom->getDeadline()->getTimestamp() - $activeUntil->getDeadline()->getTimestamp();

--- a/module/Admin/src/Admin/InputFilter/User.php
+++ b/module/Admin/src/Admin/InputFilter/User.php
@@ -194,7 +194,7 @@ class User implements InputFilterAwareInterface
                                 }*/
                                 $em = $this->getServiceLocator()
                                     ->get('Doctrine\ORM\EntityManager');
-                                $user = $em->getRepository("ErsBase\Entity\User")
+                                $user = $em->getRepository('ErsBase\Entity\User')
                                         ->findOneBy(array('email' => $value));
                                 if($user && $user->getId() != $context['id']) {
                                     return false;

--- a/module/ErsBase/Module.php
+++ b/module/ErsBase/Module.php
@@ -89,7 +89,7 @@ class Module
                 'ErsBase\Service\AgegroupService:price' => function($sm) {
                     $agegroupService = new Service\AgegroupService();
                     $em = $sm->get('Doctrine\ORM\EntityManager');
-                    $agegroups = $em->getRepository("ErsBase\Entity\Agegroup")
+                    $agegroups = $em->getRepository('ErsBase\Entity\Agegroup')
                                 ->findBy(array('price_change' => '1'));
                     $agegroupService->setAgegroups($agegroups);
                     
@@ -98,7 +98,7 @@ class Module
                 'ErsBase\Service\AgegroupService:ticket' => function($sm) {
                     $agegroupService = new Service\AgegroupService();
                     $em = $sm->get('Doctrine\ORM\EntityManager');
-                    $agegroups = $em->getRepository("ErsBase\Entity\Agegroup")
+                    $agegroups = $em->getRepository('ErsBase\Entity\Agegroup')
                                 ->findBy(array('ticket_change' => '1'));
                     $agegroupService->setAgegroups($agegroups);
                     
@@ -107,7 +107,7 @@ class Module
                 'ErsBase\Service\DeadlineService:price' => function($sm) {
                     $deadlineService = new Service\DeadlineService();
                     $em = $sm->get('Doctrine\ORM\EntityManager');
-                    $deadlines = $em->getRepository("ErsBase\Entity\Deadline")
+                    $deadlines = $em->getRepository('ErsBase\Entity\Deadline')
                                 ->findBy(array('price_change' => '1'));
                     $deadlineService->setDeadlines($deadlines);
                     
@@ -116,7 +116,7 @@ class Module
                 'ErsBase\Service\DeadlineService:noprice' => function($sm) {
                     $deadlineService = new Service\DeadlineService();
                     $em = $sm->get('Doctrine\ORM\EntityManager');
-                    $deadlines = $em->getRepository("ErsBase\Entity\Deadline")
+                    $deadlines = $em->getRepository('ErsBase\Entity\Deadline')
                                 ->findBy(array('price_change' => '0'));
                     $deadlineService->setDeadlines($deadlines);
                     
@@ -125,7 +125,7 @@ class Module
                 'ErsBase\Service\DeadlineService:all' => function($sm) {
                     $deadlineService = new Service\DeadlineService();
                     $em = $sm->get('Doctrine\ORM\EntityManager');
-                    $deadlines = $em->getRepository("ErsBase\Entity\Deadline")
+                    $deadlines = $em->getRepository('ErsBase\Entity\Deadline')
                                 ->findAll();
                     $deadlineService->setDeadlines($deadlines);
                     
@@ -140,7 +140,7 @@ class Module
                     $service = new Service\ETicketService();
                     $service->setServiceLocator($sm);
                     $em = $sm->get('Doctrine\ORM\EntityManager');
-                    $products = $em->getRepository("ErsBase\Entity\Product")
+                    $products = $em->getRepository('ErsBase\Entity\Product')
                                 ->findBy(array('visible' => '1'), array('ordering' => 'ASC'));
                     $service->setProducts($products);
                     return $service;

--- a/module/ErsBase/src/ErsBase/Service/EmailService.php
+++ b/module/ErsBase/src/ErsBase/Service/EmailService.php
@@ -243,7 +243,7 @@ class EmailService
         $this->setFrom('prereg@eja.net');
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $role = $em->getRepository("ErsBase\Entity\Role")
+        $role = $em->getRepository('ErsBase\Entity\Role')
                     ->findOneBy(array('roleId' => 'supradm'));
         $users = $role->getUsers();
         if(count($users) <= 0) {
@@ -286,7 +286,7 @@ class EmailService
             ->get('Doctrine\ORM\EntityManager');
         
         #$session_order = new Container('order');
-        $order = $em->getRepository("ErsBase\Entity\Order")
+        $order = $em->getRepository('ErsBase\Entity\Order')
                     ->findOneBy(array('id' => $order_id));
         $buyer = $order->getBuyer();
         

--- a/module/ErsBase/src/ErsBase/Service/OptionService.php
+++ b/module/ErsBase/src/ErsBase/Service/OptionService.php
@@ -44,12 +44,12 @@ class OptionService
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $qb1 = $em->getRepository("ErsBase\Entity\Country")->createQueryBuilder('n');
+        $qb1 = $em->getRepository('ErsBase\Entity\Country')->createQueryBuilder('n');
         $qb1->where($qb1->expr()->isNotNull('n.position'));
         $qb1->orderBy('n.position', 'ASC');
         $result1 = $qb1->getQuery()->getResult();
         
-        $qb2 = $em->getRepository("ErsBase\Entity\Country")->createQueryBuilder('n');
+        $qb2 = $em->getRepository('ErsBase\Entity\Country')->createQueryBuilder('n');
         $qb2->where($qb2->expr()->isNull('n.position'));
         $qb2->orderBy('n.name', 'ASC');
         $result2 = $qb2->getQuery()->getResult();
@@ -146,7 +146,7 @@ class OptionService
     public function getAgegroupOptions($agegroup_id = null) {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $agegroups = $em->getRepository("ErsBase\Entity\Agegroup")
+        $agegroups = $em->getRepository('ErsBase\Entity\Agegroup')
                     ->findBy(array('price_change' => '1'), array('agegroup' => 'DESC'));
         $options = array();
         

--- a/module/ErsBase/src/ErsBase/Service/OrderService.php
+++ b/module/ErsBase/src/ErsBase/Service/OrderService.php
@@ -144,7 +144,7 @@ class OrderService
     public function removeItemById($item_id) {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $item = $em->getRepository("ErsBase\Entity\Item")
+        $item = $em->getRepository('ErsBase\Entity\Item')
             ->findOneBy(array('id' => $item_id));
         if(!$item) {
             throw new \Exception('Unable to remove item with id: '.$item_id);

--- a/module/OnsiteReg/Module.php
+++ b/module/OnsiteReg/Module.php
@@ -227,7 +227,7 @@ class Module
                 'OnsiteReg\Service\AgegroupService:price' => function($sm) {
                     $agegroupService = new Service\AgegroupService();
                     $em = $sm->get('Doctrine\ORM\EntityManager');
-                    $agegroups = $em->getRepository("ErsBase\Entity\Agegroup")
+                    $agegroups = $em->getRepository('ErsBase\Entity\Agegroup')
                                 ->findBy(array('price_change' => '1'));
                     $agegroupService->setAgegroups($agegroups);
                     
@@ -236,7 +236,7 @@ class Module
                 'OnsiteReg\Service\AgegroupService:ticket' => function($sm) {
                     $agegroupService = new Service\AgegroupService();
                     $em = $sm->get('Doctrine\ORM\EntityManager');
-                    $agegroups = $em->getRepository("ErsBase\Entity\Agegroup")
+                    $agegroups = $em->getRepository('ErsBase\Entity\Agegroup')
                                 ->findBy(array('ticket_change' => '1'));
                     $agegroupService->setAgegroups($agegroups);
                     

--- a/module/OnsiteReg/src/OnsiteReg/Controller/RedirectController.php
+++ b/module/OnsiteReg/src/OnsiteReg/Controller/RedirectController.php
@@ -26,7 +26,7 @@ class RedirectController extends AbstractActionController {
         // get the corresponding code
         $codeValue = $this->params()->fromRoute('code', '');
         /* @var $code \ErsBase\Entity\Code */
-        $code = $em->getRepository("ErsBase\Entity\Code")
+        $code = $em->getRepository('ErsBase\Entity\Code')
                 ->findOneBy(array('value' => $codeValue));
         
         if(!$code) {

--- a/module/PreReg/src/PreReg/Controller/CartController.php
+++ b/module/PreReg/src/PreReg/Controller/CartController.php
@@ -90,7 +90,7 @@ class CartController extends AbstractActionController {
                  */
                 $em = $this->getServiceLocator()
                     ->get('Doctrine\ORM\EntityManager');
-                $product = $em->getRepository("ErsBase\Entity\Product")
+                $product = $em->getRepository('ErsBase\Entity\Product')
                         ->findOneBy(array('id' => $data['Product_id']));
 
                 /*
@@ -110,7 +110,7 @@ class CartController extends AbstractActionController {
                             ->get('ErsBase\Service\AgegroupService');
                     $agegroup = $agegroupService->getAgegroupByUser($participant);
                 } elseif($agegroup_id != 0) {
-                    $agegroup = $em->getRepository("ErsBase\Entity\Agegroup")
+                    $agegroup = $em->getRepository('ErsBase\Entity\Agegroup')
                             ->findOneBy(array('id' => $agegroup_id));
                 } else {
                     $logger->emerg('Unable to add/edit product!');
@@ -122,7 +122,7 @@ class CartController extends AbstractActionController {
                 $deadlineService = $this->getServiceLocator()
                     ->get('ErsBase\Service\DeadlineService:price');
                 /*$deadlineService = new Service\DeadlineService();
-                $deadlines = $em->getRepository("ErsBase\Entity\Deadline")
+                $deadlines = $em->getRepository('ErsBase\Entity\Deadline')
                         ->findBy(array('price_change' => '1'));
                 $deadlineService->setDeadlines($deadlines);*/
                 $deadline = $deadlineService->getDeadline();
@@ -141,7 +141,7 @@ class CartController extends AbstractActionController {
                  */
                 $variant_data = $data['pv'];
                 foreach($product->getProductVariants() as $variant) {
-                    $value = $em->getRepository("ErsBase\Entity\ProductVariantValue")
+                    $value = $em->getRepository('ErsBase\Entity\ProductVariantValue')
                         ->findOneBy(array('id' => $variant_data[$variant->getId()]));
                     if($value) {
                         $itemVariant = new Entity\ItemVariant();
@@ -156,7 +156,7 @@ class CartController extends AbstractActionController {
                 /*
                  * check product packages and add data to item entity
                  */
-                $productPackages = $em->getRepository("ErsBase\Entity\ProductPackage")
+                $productPackages = $em->getRepository('ErsBase\Entity\ProductPackage')
                     ->findBy(array('Product_id' => $product->getId()));
                 foreach($productPackages as $package) {
                     $subProduct = $package->getSubProduct();
@@ -169,7 +169,7 @@ class CartController extends AbstractActionController {
                     $subItem->populate($product_data);
 
                     foreach($subProduct->getProductVariants() as $variant) {
-                        $value = $em->getRepository("ErsBase\Entity\ProductVariantValue")
+                        $value = $em->getRepository('ErsBase\Entity\ProductVariantValue')
                             ->findOneBy(array('id' => $variant_data[$variant->getId()]));
                         if($value) {
                             $itemVariant = new Entity\ItemVariant();

--- a/module/PreReg/src/PreReg/Controller/InfoController.php
+++ b/module/PreReg/src/PreReg/Controller/InfoController.php
@@ -67,7 +67,7 @@ class InfoController extends AbstractActionController {
         $breadcrumb = $forrest->get('paymenttype');
         
         return new ViewModel(array(
-            'paymenttype' => $em->getRepository("ErsBase\Entity\PaymentType")->findOneBy(array('id' => $id)),
+            'paymenttype' => $em->getRepository('ErsBase\Entity\PaymentType')->findOneBy(array('id' => $id)),
             'breadcrumb' => $breadcrumb,
         ));
     }
@@ -109,7 +109,7 @@ class InfoController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $agegroups = $em->getRepository("ErsBase\Entity\Agegroup")
+        $agegroups = $em->getRepository('ErsBase\Entity\Agegroup')
                 ->findBy(array('ticket_change' => '1'), array('agegroup' => 'ASC'));
         
         $sel = false;
@@ -157,7 +157,7 @@ class InfoController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $agegroup = $em->getRepository("ErsBase\Entity\Agegroup")
+        $agegroup = $em->getRepository('ErsBase\Entity\Agegroup')
                 ->findOneBy(array('id' => $agegroup_id));
         
         return new ViewModel(array(

--- a/module/PreReg/src/PreReg/Controller/OrderController.php
+++ b/module/PreReg/src/PreReg/Controller/OrderController.php
@@ -91,7 +91,7 @@ class OrderController extends AbstractActionController {
         
         $agegroupService = $this->getServiceLocator()
                 ->get('ErsBase\Service\AgegroupService');
-        $agegroups = $em->getRepository("ErsBase\Entity\Agegroup")
+        $agegroups = $em->getRepository('ErsBase\Entity\Agegroup')
                     ->findBy(array('price_change' => '1'));
         $agegroupService->setAgegroups($agegroups);
         foreach($order->getPackages() as $package) {
@@ -104,7 +104,7 @@ class OrderController extends AbstractActionController {
             }
             $agegroup = $agegroupService->getAgegroupByUser($participant);
             foreach($package->getItems() as $item) {
-                $product = $em->getRepository("ErsBase\Entity\Product")
+                $product = $em->getRepository('ErsBase\Entity\Product')
                     ->findOneBy(array('id' => $item->getProductId()));
                 if($product != null) {
                     $productPrice = $product->getProductPrice($agegroup, $deadline);
@@ -129,7 +129,7 @@ class OrderController extends AbstractActionController {
         
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $order = $em->getRepository("ErsBase\Entity\Order")
+        $order = $em->getRepository('ErsBase\Entity\Order')
                 ->findOneBy(array('hashkey' => $hashkey));
         
         if($order == null) {
@@ -268,7 +268,7 @@ class OrderController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $paymenttypes = $em->getRepository("ErsBase\Entity\PaymentType")
+        $paymenttypes = $em->getRepository('ErsBase\Entity\PaymentType')
                 ->findBy(array(), array('position' => 'ASC'));
         $types = array();
         $now = new \DateTime();
@@ -310,7 +310,7 @@ class OrderController extends AbstractActionController {
             if ($form->isValid()) {
                 $data = $form->getData();
                 
-                $paymenttype = $em->getRepository("ErsBase\Entity\PaymentType")
+                $paymenttype = $em->getRepository('ErsBase\Entity\PaymentType')
                         ->findOneBy(array('id' => $data['paymenttype_id']));
                 
                 $order->setPaymentType($paymenttype);
@@ -360,12 +360,12 @@ class OrderController extends AbstractActionController {
         $em = $this->getServiceLocator()
                 ->get('Doctrine\ORM\EntityManager');
         
-        $paymenttype = $em->getRepository("ErsBase\Entity\PaymentType")
+        $paymenttype = $em->getRepository('ErsBase\Entity\PaymentType')
                         ->findOneBy(array('id' => $order->getPaymentTypeId()));
         $order->setPaymentType($paymenttype);
         
         if(isset($orderContainer->order_id)) {
-            $order = $em->getRepository("ErsBase\Entity\Order")
+            $order = $em->getRepository('ErsBase\Entity\Order')
                     ->findOneBy(array('id' => $orderContainer->order_id));
             if($order) {
                 return $this->redirect()->toRoute(
@@ -402,11 +402,11 @@ class OrderController extends AbstractActionController {
                 if($participant->getEmail() == '') {
                     $participant->setEmail(null);
                 } else {
-                    $user = $em->getRepository("ErsBase\Entity\User")
+                    $user = $em->getRepository('ErsBase\Entity\User')
                         ->findOneBy(array('email' => $participant->getEmail()));
                 }
                 
-                $role = $em->getRepository("ErsBase\Entity\Role")
+                $role = $em->getRepository('ErsBase\Entity\Role')
                         ->findOneBy(array('roleId' => 'participant'));
                 if($user instanceof Entity\User) {
                     $package->setParticipant($user);
@@ -422,7 +422,7 @@ class OrderController extends AbstractActionController {
                     #$package->setParticipantId($participant->getId());
                 }
                 
-                $country = $em->getRepository("ErsBase\Entity\Country")
+                $country = $em->getRepository('ErsBase\Entity\Country')
                         ->findOneBy(array('id' => $participant->getCountryId()));
                 if(!$country) {
                     $participant->setCountry(null);
@@ -555,7 +555,7 @@ class OrderController extends AbstractActionController {
         
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $order = $em->getRepository("ErsBase\Entity\Order")
+        $order = $em->getRepository('ErsBase\Entity\Order')
                 ->findOneBy(array('hashkey' => $hashkey));
         
         if($order == null) {
@@ -604,7 +604,7 @@ class OrderController extends AbstractActionController {
         
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $order = $em->getRepository("ErsBase\Entity\Order")
+        $order = $em->getRepository('ErsBase\Entity\Order')
                 ->findOneBy(array('hashkey' => $hashkey));
         
         if($order == null) {
@@ -637,7 +637,7 @@ class OrderController extends AbstractActionController {
         
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $order = $em->getRepository("ErsBase\Entity\Order")
+        $order = $em->getRepository('ErsBase\Entity\Order')
                 ->findOneBy(array('hashkey' => $hashkey));
         
         if($order == null) {

--- a/module/PreReg/src/PreReg/Controller/ParticipantController.php
+++ b/module/PreReg/src/PreReg/Controller/ParticipantController.php
@@ -39,7 +39,7 @@ class ParticipantController extends AbstractActionController {
         
         foreach($participants as $participant) {
             if($participant->getCountryId()) {
-                $country = $em->getRepository("ErsBase\Entity\Country")
+                $country = $em->getRepository('ErsBase\Entity\Country')
                         ->findOneBy(array('id' => $participant->getCountryId()));
                 $participant->setCountry($country);
             }

--- a/module/PreReg/src/PreReg/Controller/PaymentController.php
+++ b/module/PreReg/src/PreReg/Controller/PaymentController.php
@@ -33,7 +33,7 @@ class PaymentController extends AbstractActionController {
         
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $order = $em->getRepository("ErsBase\Entity\Order")
+        $order = $em->getRepository('ErsBase\Entity\Order')
                 ->findOneBy(array('hashkey' => $hashkey));
         
         return new ViewModel(array(
@@ -53,7 +53,7 @@ class PaymentController extends AbstractActionController {
         
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $order = $em->getRepository("ErsBase\Entity\Order")
+        $order = $em->getRepository('ErsBase\Entity\Order')
                 ->findOneBy(array('hashkey' => $hashkey));
         
         return new ViewModel(array(
@@ -73,7 +73,7 @@ class PaymentController extends AbstractActionController {
         
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $order = $em->getRepository("ErsBase\Entity\Order")
+        $order = $em->getRepository('ErsBase\Entity\Order')
                 ->findOneBy(array('hashkey' => $hashkey));
         
         //setup config object
@@ -123,7 +123,7 @@ class PaymentController extends AbstractActionController {
         
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $order = $em->getRepository("ErsBase\Entity\Order")
+        $order = $em->getRepository('ErsBase\Entity\Order')
                 ->findOneBy(array('hashkey' => $hashkey));
         
        
@@ -289,7 +289,7 @@ class PaymentController extends AbstractActionController {
         
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $order = $em->getRepository("ErsBase\Entity\Order")
+        $order = $em->getRepository('ErsBase\Entity\Order')
                 ->findOneBy(array('hashkey' => $hashkey));
         
         if($order == null) {

--- a/module/PreReg/src/PreReg/Controller/ProductController.php
+++ b/module/PreReg/src/PreReg/Controller/ProductController.php
@@ -27,7 +27,7 @@ class ProductController extends AbstractActionController {
         
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $tmp = $em->getRepository("ErsBase\Entity\Product")
+        $tmp = $em->getRepository('ErsBase\Entity\Product')
             ->findBy(
                     array(
                         'active' => 1,
@@ -45,7 +45,7 @@ class ProductController extends AbstractActionController {
             }
         }
         
-        $agegroups = $em->getRepository("ErsBase\Entity\Agegroup")
+        $agegroups = $em->getRepository('ErsBase\Entity\Agegroup')
                     ->findBy(array('price_change' => '1'), array('agegroup' => 'DESC'));
         
         $deadlineService = $this->getServiceLocator()
@@ -140,7 +140,7 @@ class ProductController extends AbstractActionController {
          */
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $product = $em->getRepository("ErsBase\Entity\Product")
+        $product = $em->getRepository('ErsBase\Entity\Product')
                 ->findOneBy(array('id' => $product_id));
         $status = $em->getRepository('ErsBase\Entity\Status')
                 ->findOneBy(array('value' => 'order pending'));
@@ -153,7 +153,7 @@ class ProductController extends AbstractActionController {
         /*
          * Get variants for this product and subproducts
          */
-        $variants = $em->getRepository("ErsBase\Entity\ProductVariant")
+        $variants = $em->getRepository('ErsBase\Entity\ProductVariant')
                 ->findBy(array('Product_id' => $product_id));
         $defaults = $this->params()->fromQuery();
         
@@ -162,11 +162,11 @@ class ProductController extends AbstractActionController {
             $package_info[$variant->getId()] = false;
         }
         
-        $productPackages = $em->getRepository("ErsBase\Entity\ProductPackage")
+        $productPackages = $em->getRepository('ErsBase\Entity\ProductPackage')
                 ->findBy(array('Product_id' => $product_id));
         foreach($productPackages as $package) {
             $subProduct = $package->getSubProduct();
-            $subVariants = $em->getRepository("ErsBase\Entity\ProductVariant")
+            $subVariants = $em->getRepository('ErsBase\Entity\ProductVariant')
                 ->findBy(array('Product_id' => $subProduct->getId()));
             foreach($subVariants as $variant) {
                 $package_info[$variant->getId()] = true;
@@ -234,7 +234,7 @@ class ProductController extends AbstractActionController {
                  */
                 $em = $this->getServiceLocator()
                     ->get('Doctrine\ORM\EntityManager');
-                $product = $em->getRepository("ErsBase\Entity\Product")
+                $product = $em->getRepository('ErsBase\Entity\Product')
                         ->findOneBy(array('id' => $data['Product_id']));
 
                 /*
@@ -250,7 +250,7 @@ class ProductController extends AbstractActionController {
                         $agegroup = $agegroupService->getAgegroupByUser($participant);
                     }
                 } elseif($agegroup_id != 0) {
-                    $agegroup = $em->getRepository("ErsBase\Entity\Agegroup")
+                    $agegroup = $em->getRepository('ErsBase\Entity\Agegroup')
                             ->findOneBy(array('id' => $agegroup_id));
                 } else {
                     $logger->emerg('Unable to add/edit product!');
@@ -281,7 +281,7 @@ class ProductController extends AbstractActionController {
                  */
                 $variant_data = $data['pv'];
                 foreach($product->getProductVariants() as $variant) {
-                    $value = $em->getRepository("ErsBase\Entity\ProductVariantValue")
+                    $value = $em->getRepository('ErsBase\Entity\ProductVariantValue')
                         ->findOneBy(array('id' => $variant_data[$variant->getId()]));
                     if($value && !$value->getDisabled()) {
                         $itemVariant = new Entity\ItemVariant();
@@ -308,7 +308,7 @@ class ProductController extends AbstractActionController {
                 /*
                  * check product packages and add data to item entity
                  */
-                $productPackages = $em->getRepository("ErsBase\Entity\ProductPackage")
+                $productPackages = $em->getRepository('ErsBase\Entity\ProductPackage')
                     ->findBy(array('Product_id' => $product->getId()));
                 foreach($productPackages as $package) {
                     $subProduct = $package->getSubProduct();
@@ -327,7 +327,7 @@ class ProductController extends AbstractActionController {
 
                     $add = false;
                     foreach($subProduct->getProductVariants() as $variant) {
-                        $value = $em->getRepository("ErsBase\Entity\ProductVariantValue")
+                        $value = $em->getRepository('ErsBase\Entity\ProductVariantValue')
                             ->findOneBy(array('id' => $variant_data[$variant->getId()]));
                         if($value && !$value->getDisabled()) {
                             $add = true;
@@ -416,7 +416,7 @@ class ProductController extends AbstractActionController {
         $chooser = $cartContainer->chooser;
         $cartContainer->chooser = false;
 
-        $agegroups = $em->getRepository("ErsBase\Entity\Agegroup")
+        $agegroups = $em->getRepository('ErsBase\Entity\Agegroup')
                     ->findBy(array('price_change' => '1'), array('agegroup' => 'DESC'));
         
         $participantForm = new Form\Participant(); 

--- a/module/PreReg/src/PreReg/Controller/ProfileController.php
+++ b/module/PreReg/src/PreReg/Controller/ProfileController.php
@@ -29,7 +29,7 @@ class ProfileController extends AbstractActionController {
 
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $user = $em->getRepository("ErsBase\Entity\User")->findOneBy(array('email' => $email));
+        $user = $em->getRepository('ErsBase\Entity\User')->findOneBy(array('email' => $email));
         
         return new ViewModel(array(
             'user' => $user,
@@ -45,7 +45,7 @@ class ProfileController extends AbstractActionController {
             ->get('Doctrine\ORM\EntityManager');
         
         $email = $this->zfcUserAuthentication()->getIdentity()->getEmail();
-        $user = $em->getRepository("ErsBase\Entity\User")->findOneBy(array('email' => $email));
+        $user = $em->getRepository('ErsBase\Entity\User')->findOneBy(array('email' => $email));
         
         $form = new Form\User(); 
         $request = $this->getRequest(); 
@@ -127,7 +127,7 @@ class ProfileController extends AbstractActionController {
                 
                 $em = $this->getServiceLocator()
                     ->get('Doctrine\ORM\EntityManager');
-                $user = $em->getRepository("ErsBase\Entity\User")
+                $user = $em->getRepository('ErsBase\Entity\User')
                         ->findOneBy(array('email' => $data['email']));
                 if($user) {
                     $user->genHashKey();
@@ -176,7 +176,7 @@ class ProfileController extends AbstractActionController {
         
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $user = $em->getRepository("ErsBase\Entity\User")
+        $user = $em->getRepository('ErsBase\Entity\User')
                 ->findOneBy(array('hashkey' => $hashkey));
         if(!$user) {
             $logger->info('unable to find user with hash key: '.$hashkey);
@@ -207,7 +207,7 @@ class ProfileController extends AbstractActionController {
                 $user->setPassword($password);
                 $user->setHashKey(null);
                 
-                $role = $em->getRepository("ErsBase\Entity\Role")
+                $role = $em->getRepository('ErsBase\Entity\Role')
                     ->findOneBy(array('roleId' => 'user'));
                 if(!$user->hasRole($role)) {
                     $user->addRole($role);
@@ -236,7 +236,7 @@ class ProfileController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $participant = $em->getRepository("ErsBase\Entity\User")
+        $participant = $em->getRepository('ErsBase\Entity\User')
             ->findOneBy(array('email' => $email));
         
         #$form = new Form\Participant(); 
@@ -290,12 +290,12 @@ class ProfileController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $qb1 = $em->getRepository("ErsBase\Entity\Country")->createQueryBuilder('n');
+        $qb1 = $em->getRepository('ErsBase\Entity\Country')->createQueryBuilder('n');
         $qb1->where($qb1->expr()->isNotNull('n.position'));
         $qb1->orderBy('n.position', 'ASC');
         $result1 = $qb1->getQuery()->getResult();
         
-        $qb2 = $em->getRepository("ErsBase\Entity\Country")->createQueryBuilder('n');
+        $qb2 = $em->getRepository('ErsBase\Entity\Country')->createQueryBuilder('n');
         $qb2->where($qb2->expr()->isNull('n.position'));
         $qb2->orderBy('n.name', 'ASC');
         $result2 = $qb2->getQuery()->getResult();

--- a/module/PreReg/src/PreReg/Controller/TestController.php
+++ b/module/PreReg/src/PreReg/Controller/TestController.php
@@ -40,7 +40,7 @@ class TestController extends AbstractActionController {
             $code = new Entity\Code();
             $code->genCode();
             
-            $code = $em->getRepository("ErsBase\Entity\Code")->findOneBy(array('value' => $code->getValue()));
+            $code = $em->getRepository('ErsBase\Entity\Code')->findOneBy(array('value' => $code->getValue()));
             #if(in_array($code->getValue(), $codes)) {
             if($code) {
                 $logger->info('found existing code after '.$count.' tries.');
@@ -76,7 +76,7 @@ class TestController extends AbstractActionController {
         
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $user = $em->getRepository("ErsBase\Entity\User")->findOneBy(array('email' => 'andi@sixhop.net'));
+        $user = $em->getRepository('ErsBase\Entity\User')->findOneBy(array('email' => 'andi@sixhop.net'));
         $user = new Entity\User();
         $user->setEmail('andi@inbaz.org');
         $emailService->addTo($user);
@@ -137,7 +137,7 @@ class TestController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $order = $em->getRepository("ErsBase\Entity\Order")
+        $order = $em->getRepository('ErsBase\Entity\Order')
                     ->findOneBy(array('id' => '87'));
         
         if($order == null) {
@@ -275,7 +275,7 @@ class TestController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $order = $em->getRepository("ErsBase\Entity\Order")
+        $order = $em->getRepository('ErsBase\Entity\Order')
                 #->findOneBy(array('id' => '297'));
                 ->findOneBy(array('id' => '12'));
                 #->findOneBy(array('id' => '54'));
@@ -296,7 +296,7 @@ class TestController extends AbstractActionController {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
         
-        $order = $em->getRepository("ErsBase\Entity\Order")
+        $order = $em->getRepository('ErsBase\Entity\Order')
                     ->findOneBy(array('id' => '17'));
         $viewModel = new ViewModel(array(
             'order' => $order,
@@ -319,7 +319,7 @@ class TestController extends AbstractActionController {
         
         #$logger = $this->getServiceLocator()->get('Logger');
         
-        $order = $em->getRepository("ErsBase\Entity\Order")
+        $order = $em->getRepository('ErsBase\Entity\Order')
                     ->findOneBy(array('id' => '17'));
         $viewModel = new ViewModel(array(
             'order' => $order,

--- a/module/PreReg/src/PreReg/InputFilter/PaymentType.php
+++ b/module/PreReg/src/PreReg/InputFilter/PaymentType.php
@@ -60,7 +60,7 @@ class PaymentType implements InputFilterAwareInterface
                                 $em = $this->getServiceLocator()
                                     ->get('Doctrine\ORM\EntityManager');
                                 
-                                $paymenttype = $em->getRepository("ErsBase\Entity\PaymentType")
+                                $paymenttype = $em->getRepository('ErsBase\Entity\PaymentType')
                                     ->findOneBy(array('id' => $value));
                                 
                                 $now = new \DateTime();

--- a/module/PreReg/src/PreReg/InputFilter/Register.php
+++ b/module/PreReg/src/PreReg/InputFilter/Register.php
@@ -117,7 +117,7 @@ class Register implements InputFilterAwareInterface
                                 $em = $this->getServiceLocator()
                                     ->get('Doctrine\ORM\EntityManager');
                                 
-                                $user = $em->getRepository("ErsBase\Entity\User")->findOneBy(array(
+                                $user = $em->getRepository('ErsBase\Entity\User')->findOneBy(array(
                                     'email' => $participant->getEmail(),
                                     'active' => true,
                                     ));

--- a/module/PreReg/src/PreReg/Service/LoginService.php
+++ b/module/PreReg/src/PreReg/Service/LoginService.php
@@ -56,7 +56,7 @@ class LoginService
     public function setUserId($user_id) {
         $em = $this->getServiceLocator()
             ->get('Doctrine\ORM\EntityManager');
-        $this->setUser($em->getRepository("ErsBase\Entity\User")
+        $this->setUser($em->getRepository('ErsBase\Entity\User')
                 ->findOneBy(array('id' => $user_id)));
     }
     
@@ -111,7 +111,7 @@ class LoginService
                 if(isset($countries[$newUser->getCountryId()])) {
                     $country = $countries[$newUser->getCountryId()];
                 } else {
-                    $country = $em->getRepository("ErsBase\Entity\Country")
+                    $country = $em->getRepository('ErsBase\Entity\Country')
                         ->findOneBy(array('id' => $newUser->getCountryId()));
                     $countries[$country->getId()] = $country;
                 }
@@ -133,7 +133,7 @@ class LoginService
             /*
              * add users from former orders
              */
-            $orders = $em->getRepository("ErsBase\Entity\Order")
+            $orders = $em->getRepository('ErsBase\Entity\Order')
                 ->findBy(array('buyer_id' => $this->getUser()->getId()));
         
             foreach($orders as $order) {
@@ -147,7 +147,7 @@ class LoginService
                         if(isset($countries[$newUser->getCountryId()])) {
                             $country = $countries[$newUser->getCountryId()];
                         } else {
-                            $country = $em->getRepository("ErsBase\Entity\Country")
+                            $country = $em->getRepository('ErsBase\Entity\Country')
                                 ->findOneBy(array('id' => $newUser->getCountryId()));
                             $countries[$country->getId()] = $country;
                         }


### PR DESCRIPTION
Since backslashes in double-quoted strings are usually escape characters,
but not here. Using single quotes makes that more clear,
even though nothing was actually broken with double quotes.

http://php.net/manual/en/language.types.string.php